### PR TITLE
Do not follow symlinks

### DIFF
--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -69,7 +69,7 @@ class BuildExamplesCommand extends PluginCommand {
               entity is Directory && p.basename(entity.path) == 'example')
           .where((FileSystemEntity entity) {
         final Directory dir = entity;
-        return dir.listSync().any((FileSystemEntity entity) =>
+        return dir.listSync(followLinks: false).any((FileSystemEntity entity) =>
             entity is File && p.basename(entity.path) == 'pubspec.yaml');
       });
 }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -33,17 +33,18 @@ abstract class PluginCommand extends Command<Null> {
   Stream<FileSystemEntity> getPluginFiles({bool recursive: false}) {
     final List<String> packages = argResults[_pluginsArg];
     if (packages.isEmpty) {
-      return packagesDir.list(recursive: recursive);
+      return packagesDir.list(recursive: recursive, followLinks: false);
     } else {
-      final List<Directory> filteredPackages = packagesDir.listSync().where(
-          (FileSystemEntity entity) =>
+      final List<Directory> filteredPackages = packagesDir
+          .listSync(followLinks: false)
+          .where((FileSystemEntity entity) =>
               entity is Directory &&
               packages.contains(p.basename(entity.path)));
       if (recursive) {
         final List<Stream<FileSystemEntity>> streams =
             <Stream<FileSystemEntity>>[];
         for (Directory directory in filteredPackages) {
-          streams.add(directory.list(recursive: true));
+          streams.add(directory.list(recursive: true, followLinks: false));
         }
         return StreamGroup.merge(streams);
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.6
+version: 0.0.7
 
 dependencies:
   args: "^0.13.7"


### PR DESCRIPTION
Cocoapods are symlinked so we'd run the same tools twice in some cases.

```
BUILDING IPA for firebase_auth/example/ios/Pods/.symlinks/plugins/firebase_auth/example/ios/Pods/.symlinks/plugins/google_sign_in/example
```