### PR TITLE
Add sharding support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: dart
 dart:
-- stable
 - dev
 dart_task:
 - dartanalyzer: --fatal-warnings --fatal-hints --fatal-lints --lints lib/ bin/

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ testing on Travis for these repositories (see [travis.yaml](https://github.com/f
 As an example, Flutter Plugin Tools allows you to:
 
 * Build all plugin example apps with one command
-* Run the tests of all pluigns with one command
+* Run the tests of all plugins with one command
 * Format all Dart, Java, and Objective-C code in the repository
+* Define shards of the above tasks
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ To use all features of `flutter_plugin_tools` you'll need the following commands
 
 ```shell
 $ pub global run flutter_plugin_tools <command>
+$ pub global run flutter_plugin_tools <command> --shardIndex 0 --shardCount 3
 ```
 
 Replace `<command>` with `help` to print a list of available commands.
+The sharded example above divides the plugins into three shards
+and executes the tool on the first shard (index 0).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,9 +20,7 @@
 
 analyzer:
   language:
-    enableStrictCallChecks: true
     enableSuperMixins: true
-    enableAssertInitializer: true
   strong-mode:
     implicit-dynamic: false
   errors:

--- a/lib/src/analyze_command.dart
+++ b/lib/src/analyze_command.dart
@@ -21,6 +21,7 @@ class AnalyzeCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     print('Activating tuneup package...');
     await runAndStream('pub', <String>['global', 'activate', 'tuneup'],
         workingDir: packagesDir, exitOnError: true);

--- a/lib/src/analyze_command.dart
+++ b/lib/src/analyze_command.dart
@@ -25,13 +25,13 @@ class AnalyzeCommand extends PluginCommand {
     await runAndStream('pub', <String>['global', 'activate', 'tuneup'],
         workingDir: packagesDir, exitOnError: true);
 
-    await for (Directory package in _listAllPackages()) {
+    await for (Directory package in getPackages()) {
       await runAndStream('flutter', <String>['packages', 'get'],
           workingDir: package, exitOnError: true);
     }
 
     final List<String> failingPackages = <String>[];
-    await for (Directory package in _listAllPluginPackages()) {
+    await for (Directory package in getPlugins()) {
       final int exitCode = await runAndStream(
           'pub', <String>['global', 'run', 'tuneup', 'check'],
           workingDir: package);
@@ -51,14 +51,4 @@ class AnalyzeCommand extends PluginCommand {
 
     print('No analyzer errors found!');
   }
-
-  Stream<Directory> _listAllPluginPackages() =>
-      getPluginFiles().where((FileSystemEntity entity) =>
-          entity is Directory &&
-          new File(p.join(entity.path, 'pubspec.yaml')).existsSync());
-
-  Stream<Directory> _listAllPackages() => getPluginFiles(recursive: true)
-      .where((FileSystemEntity entity) =>
-          entity is File && p.basename(entity.path) == 'pubspec.yaml')
-      .map((FileSystemEntity entity) => entity.parent);
 }

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -25,6 +25,7 @@ class BuildExamplesCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     final List<String> failingPackages = <String>[];
     await for (Directory example in getExamples()) {
       final String packageName =

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -26,7 +26,7 @@ class BuildExamplesCommand extends PluginCommand {
   @override
   Future<Null> run() async {
     final List<String> failingPackages = <String>[];
-    await for (Directory example in getExamplePackages()) {
+    await for (Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
 

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -26,7 +26,8 @@ abstract class PluginCommand extends Command<Null> {
       _pluginsArg,
       allowMultiple: true,
       splitCommas: true,
-      help: 'Specifies which plugins the command should run on (before sharding).',
+      help:
+          'Specifies which plugins the command should run on (before sharding).',
       valueHelp: 'plugin1,plugin2,...',
     );
     argParser.addOption(

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -17,7 +17,7 @@ class ToolExit extends Error {
 
 abstract class PluginCommand extends Command<Null> {
   static const String _pluginsArg = 'plugins';
-  static const String _shardArg = 'shard';
+  static const String _shardIndexArg = 'shardIndex';
   static const String _shardCountArg = 'shardCount';
   final Directory packagesDir;
 
@@ -26,11 +26,11 @@ abstract class PluginCommand extends Command<Null> {
       _pluginsArg,
       allowMultiple: true,
       splitCommas: true,
-      help: 'Specifies which plugins the command should run on.',
+      help: 'Specifies which plugins the command should run on (before sharding).',
       valueHelp: 'plugin1,plugin2,...',
     );
     argParser.addOption(
-      _shardArg,
+      _shardIndexArg,
       help: 'Specifies the zero-based index of the shard to '
           'which the command applies.',
       valueHelp: 'i',
@@ -46,19 +46,20 @@ abstract class PluginCommand extends Command<Null> {
 
   @override
   FutureOr<Null> run() {
-    final int shard = int.tryParse(argResults[_shardArg]);
+    final int shardIndex = int.tryParse(argResults[_shardIndexArg]);
     final int shardCount = int.tryParse(argResults[_shardCountArg]);
-    if (shard == null) {
-      usageException('shard must be an integer');
+    if (shardIndex == null) {
+      usageException('$_shardIndexArg must be an integer');
     }
     if (shardCount == null) {
-      usageException('shardCount must be an integer');
+      usageException('$_shardCountArg must be an integer');
     }
     if (shardCount < 1) {
-      usageException('shardCount must be positive');
+      usageException('$_shardCountArg must be positive');
     }
-    if (shard < 0 || shardCount <= shard) {
-      usageException('shard must be in the half-open range [0..$shardCount[');
+    if (shardIndex < 0 || shardCount <= shardIndex) {
+      usageException(
+          '$_shardIndexArg must be in the half-open range [0..$shardCount[');
     }
     return super.run();
   }
@@ -67,7 +68,7 @@ abstract class PluginCommand extends Command<Null> {
   /// command execution.
   Stream<Directory> getPlugins() {
     final int shardCount = int.parse(argResults[_shardCountArg]);
-    final int shard = int.parse(argResults[_shardArg]);
+    final int shard = int.parse(argResults[_shardIndexArg]);
     final Set<String> packages = new Set<String>.from(argResults[_pluginsArg]);
     int i = 0;
     return packagesDir

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -33,6 +33,7 @@ class FormatCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     final String googleFormatterPath = await _getGoogleFormatterPath();
 
     await _formatDart();

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -100,10 +100,9 @@ class FormatCommand extends PluginCommand {
   }
 
   Future<List<String>> _getFilesWithExtension(String extension) async =>
-      getPluginFiles(recursive: true)
-          .where((FileSystemEntity entity) =>
-              entity is File && p.extension(entity.path) == extension)
-          .map((FileSystemEntity entity) => entity.path)
+      getFiles()
+          .where((File file) => p.extension(file.path) == extension)
+          .map((File file) => file.path)
           .toList();
 
   Future<String> _getGoogleFormatterPath() async {

--- a/lib/src/java_test_command.dart
+++ b/lib/src/java_test_command.dart
@@ -24,7 +24,7 @@ class JavaTestCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
-    final Stream<Directory> examplesWithTests = getExamplePackages().where(
+    final Stream<Directory> examplesWithTests = getExamples().where(
         (Directory d) =>
             new Directory(p.join(d.path, 'android', 'app', 'src', 'test'))
                 .existsSync());

--- a/lib/src/java_test_command.dart
+++ b/lib/src/java_test_command.dart
@@ -24,6 +24,7 @@ class JavaTestCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     final Stream<Directory> examplesWithTests = getExamples().where(
         (Directory d) =>
             new Directory(p.join(d.path, 'android', 'app', 'src', 'test'))

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -31,6 +31,7 @@ class ListCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     switch (argResults[_type]) {
       case _plugin:
         await for (Directory package in getPlugins()) {

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -1,0 +1,57 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'common.dart';
+
+class ListCommand extends PluginCommand {
+  static const String _type = 'type';
+  static const String _plugin = 'plugin';
+  static const String _example = 'example';
+  static const String _package = 'package';
+  static const String _file = 'file';
+
+  ListCommand(Directory packagesDir) : super(packagesDir) {
+    argParser.addOption(
+      _type,
+      defaultsTo: _plugin,
+      allowed: <String>[_plugin, _example, _package, _file],
+      help: 'What type of file system content to list.',
+    );
+  }
+
+  @override
+  final String name = 'list';
+
+  @override
+  final String description = 'Lists packages or files';
+
+  @override
+  Future<Null> run() async {
+    switch (argResults[_type]) {
+      case _plugin:
+        await for (Directory package in getPlugins()) {
+          print(package.path);
+        }
+        break;
+      case _example:
+        await for (Directory package in getExamples()) {
+          print(package.path);
+        }
+        break;
+      case _package:
+        await for (Directory package in getPackages()) {
+          print(package.path);
+        }
+        break;
+      case _file:
+        await for (File file in getFiles()) {
+          print(file.path);
+        }
+        break;
+    }
+  }
+}

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -12,6 +12,7 @@ import 'build_examples_command.dart';
 import 'common.dart';
 import 'format_command.dart';
 import 'java_test_command.dart';
+import 'list_command.dart';
 import 'test_command.dart';
 
 void main(List<String> args) {
@@ -34,7 +35,8 @@ void main(List<String> args) {
     ..addCommand(new AnalyzeCommand(packagesDir))
     ..addCommand(new FormatCommand(packagesDir))
     ..addCommand(new BuildExamplesCommand(packagesDir))
-    ..addCommand(new JavaTestCommand(packagesDir));
+    ..addCommand(new JavaTestCommand(packagesDir))
+    ..addCommand(new ListCommand(packagesDir));
 
   commandRunner.run(args).catchError((ToolExit e) {
     exit(e.exitCode);

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -21,6 +21,7 @@ class TestCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
+    checkSharding();
     final List<String> failingPackages = <String>[];
     await for (Directory packageDir in getPackages()) {
       final String packageName =

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
@@ -22,7 +23,7 @@ class TestCommand extends PluginCommand {
   @override
   Future<Null> run() async {
     final List<String> failingPackages = <String>[];
-    await for (Directory packageDir in _listAllPackages()) {
+    await for (Directory packageDir in getPackages()) {
       final String packageName =
           p.relative(packageDir.path, from: packagesDir.path);
       if (!new Directory(p.join(packageDir.path, 'test')).existsSync()) {
@@ -50,9 +51,4 @@ class TestCommand extends PluginCommand {
 
     print('All tests are passing!');
   }
-
-  Stream<Directory> _listAllPackages() => getPluginFiles(recursive: true)
-      .where((FileSystemEntity entity) =>
-          entity is File && p.basename(entity.path) == 'pubspec.yaml')
-      .map((FileSystemEntity entity) => entity.parent);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.8
+version: 0.0.9
 
 dependencies:
   args: "^0.13.7"


### PR DESCRIPTION
We are running out of standard Travis build time for the apk build + java test shard. One counter measure is to have our plugin tooling support sharding along the plugin dimension.

Use of this facility to appear in `flutter/plugins/.travis.yaml`.