### PR TITLE
Ensure plugins are part of getPackages output

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -125,11 +125,13 @@ abstract class PluginCommand extends Command<Null> {
 
   /// Returns all Dart package folders (typically, plugin + example) of the
   /// plugins involved in this command execution.
-  Stream<Directory> getPackages() {
-    return getPlugins().asyncExpand<Directory>((Directory folder) => folder
-        .list(recursive: true, followLinks: false)
+  Stream<Directory> getPackages() async* {
+    await for (Directory plugin in getPlugins()) {
+      yield plugin;
+      yield* plugin.list(recursive: true, followLinks: false)
         .where(_isDartPackage)
-        .cast<Directory>());
+        .cast<Directory>();
+      }
   }
 
   /// Returns the files contained, recursively, within the plugins

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -128,10 +128,11 @@ abstract class PluginCommand extends Command<Null> {
   Stream<Directory> getPackages() async* {
     await for (Directory plugin in getPlugins()) {
       yield plugin;
-      yield* plugin.list(recursive: true, followLinks: false)
-        .where(_isDartPackage)
-        .cast<Directory>();
-      }
+      yield* plugin
+          .list(recursive: true, followLinks: false)
+          .where(_isDartPackage)
+          .cast<Directory>();
+    }
   }
 
   /// Returns the files contained, recursively, within the plugins


### PR DESCRIPTION
Recent refactoring failed to include plugin packages as part of `getPackages`. As a result, analysis CI jobs started failing (https://travis-ci.org/flutter/plugins/jobs/393076453)