### PR TITLE
Fix return value type mismatch (dart upgrade issue).

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -160,7 +160,7 @@ abstract class PluginCommand extends Command<Null> {
     // Only look at the subdirectories of the example directory if the example
     // directory itself is not a Dart package, and only look one level below the
     // example directory for other dart packages.
-    return exampleFolder.listSync().where(_isDartPackage);
+    return exampleFolder.listSync().where(_isDartPackage).cast<Directory>();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.10+2
+version: 0.0.11
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Plugin PRs are probably failing because of this:

```
type 'WhereIterable<FileSystemEntity>' is not a subtype of type 'List<Directory>'
#0      PluginCommand._getExamplesForPlugin (package:flutter_plugin_tools/src/common.dart:163:37)
#1      _ExpandStream._handleData (dart:async/stream_pipe.dart:248:23)
#2      _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:164:13)
#3      _RootZone.runUnaryGuarded (dart:async/zone.dart:1316:10)
#4      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:336:11)
#5      _DelayedData.perform (dart:async/stream_impl.dart:584:14)
#6      _StreamImplEvents.handleNext (dart:async/stream_impl.dart:700:11)
#7      _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:660:7)
#8      _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
#9      _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
#10     _runPendingImmediateCallback (dart:isolate/runtime/libisolate_patch.dart:113:13)
#11     _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:166:5)
```