### PR TITLE
Fix constructor sorting, support non-Flutter packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## v0.0.13
+
+- Differentiate between Flutter and non-Flutter (but potentially Flutter consumed) Dart packages.

--- a/lib/src/analyze_command.dart
+++ b/lib/src/analyze_command.dart
@@ -27,8 +27,13 @@ class AnalyzeCommand extends PluginCommand {
         workingDir: packagesDir, exitOnError: true);
 
     await for (Directory package in getPackages()) {
-      await runAndStream('flutter', <String>['packages', 'get'],
-          workingDir: package, exitOnError: true);
+      if (isFlutterPackage(package)) {
+        await runAndStream('flutter', <String>['packages', 'get'],
+            workingDir: package, exitOnError: true);
+      } else {
+        await runAndStream('pub', <String>['get'],
+            workingDir: package, exitOnError: true);
+      }
     }
 
     final List<String> failingPackages = <String>[];

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -37,13 +37,6 @@ class ToolExit extends Error {
 }
 
 abstract class PluginCommand extends Command<Null> {
-  static const String _pluginsArg = 'plugins';
-  static const String _shardIndexArg = 'shardIndex';
-  static const String _shardCountArg = 'shardCount';
-  final Directory packagesDir;
-  int _shardIndex;
-  int _shardCount;
-
   PluginCommand(this.packagesDir) {
     argParser.addMultiOption(
       _pluginsArg,
@@ -66,6 +59,13 @@ abstract class PluginCommand extends Command<Null> {
       defaultsTo: '1',
     );
   }
+
+  static const String _pluginsArg = 'plugins';
+  static const String _shardIndexArg = 'shardIndex';
+  static const String _shardCountArg = 'shardCount';
+  final Directory packagesDir;
+  int _shardIndex;
+  int _shardCount;
 
   int get shardIndex {
     if (_shardIndex == null) {

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -93,6 +93,8 @@ class FormatCommand extends PluginCommand {
   }
 
   Future<Null> _formatDart() async {
+    // This acutally should be fine for non-Flutter dart projects, no need to specifically
+    // shell out to dartfmt -w in that case.
     print('Formatting all .dart files...');
     final Iterable<String> dartFiles = await _getFilesWithExtension('.dart');
     await runAndStream('flutter', <String>['format']..addAll(dartFiles),

--- a/lib/src/java_test_command.dart
+++ b/lib/src/java_test_command.dart
@@ -27,6 +27,7 @@ class JavaTestCommand extends PluginCommand {
     checkSharding();
     final Stream<Directory> examplesWithTests = getExamples().where(
         (Directory d) =>
+            isFlutterPackage(d) &&
             new Directory(p.join(d.path, 'android', 'app', 'src', 'test'))
                 .existsSync());
 

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -8,12 +8,6 @@ import 'dart:io';
 import 'common.dart';
 
 class ListCommand extends PluginCommand {
-  static const String _type = 'type';
-  static const String _plugin = 'plugin';
-  static const String _example = 'example';
-  static const String _package = 'package';
-  static const String _file = 'file';
-
   ListCommand(Directory packagesDir) : super(packagesDir) {
     argParser.addOption(
       _type,
@@ -22,6 +16,12 @@ class ListCommand extends PluginCommand {
       help: 'What type of file system content to list.',
     );
   }
+
+  static const String _type = 'type';
+  static const String _plugin = 'plugin';
+  static const String _example = 'example';
+  static const String _package = 'package';
+  static const String _file = 'file';
 
   @override
   final String name = 'list';

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -32,9 +32,11 @@ class TestCommand extends PluginCommand {
       }
 
       print('RUNNING $packageName tests...');
-      final int exitCode = await runAndStream(
-          'flutter', <String>['test', '--color'],
-          workingDir: packageDir);
+      final int exitCode = isFlutterPackage(packageDir)
+          ? await runAndStream('flutter', <String>['test', '--color'],
+              workingDir: packageDir)
+          : await runAndStream('pub', <String>['run', 'test'],
+              workingDir: packageDir);
       if (exitCode != 0) {
         failingPackages.add(packageName);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,14 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.12
+version: 0.0.13
 
 dependencies:
   args: "^1.4.3"
   path: "^1.6.1"
   http: "^0.11.3+17"
   async: "^2.0.7"
+  yaml: "^2.1.15"
 
 environment:
   sdk: ">=1.8.0 <3.0.0"


### PR DESCRIPTION
In support of https://github.com/flutter/packages/pull/7

Want to be able to use this for CI for non-Flutter dependent packages.