### PR TITLE
Update google-java-format from 1.3 to 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/
-google-java-format-1.3-all-deps.jar
+google-java-format-*-all-deps.jar
 
 # See https://www.dartlang.org/tools/private-files.html
 

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -13,7 +13,7 @@ import 'package:quiver/iterables.dart';
 import 'common.dart';
 
 const String _googleFormatterUrl =
-    'https://github.com/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar';
+    'https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar';
 
 class FormatCommand extends PluginCommand {
   FormatCommand(Directory packagesDir) : super(packagesDir) {
@@ -119,7 +119,7 @@ class FormatCommand extends PluginCommand {
   Future<String> _getGoogleFormatterPath() async {
     final String javaFormatterPath = p.join(
         p.dirname(p.fromUri(Platform.script)),
-        'google-java-format-1.3-all-deps.jar');
+        'google-java-format-1.7-all-deps.jar');
     final File javaFormatterFile = new File(javaFormatterPath);
 
     if (!javaFormatterFile.existsSync()) {


### PR DESCRIPTION
plugin_tools is currently using google-java-format v1.3 which is over 2 years old. This updates it to the newest version, v1.7.

https://github.com/google/google-java-format/releases

~~I will also create a pull request that updates the Java style to match the newest version in the flutter/plugins repo.~~

Edit: Here's the related PR: flutter/plugins#1547