### PR TITLE
Fix formatting issue

### DIFF
--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -121,8 +121,7 @@ class VersionCheckCommand extends PluginCommand {
             await gitVersionFinder.getPackageVersion(pubspecPath, baseSha);
         final Version headVersion =
             await gitVersionFinder.getPackageVersion(pubspecPath, 'HEAD');
-        if (headVersion == null)
-            continue;  // Example apps don't have versions
+        if (headVersion == null) continue; // Example apps don't have versions
 
         final Map<Version, NextVersionType> allowedNextVersions =
             getAllowedNextVersions(masterVersion, headVersion);


### PR DESCRIPTION
Follow-up to #40, fixing a formatting issue that caused tests to fail before publishing

Not sure how I missed this, I think GitHub might have shown a green check mark without actually running tests?

<img width="621" alt="Screen Shot 2019-07-08 at 10 14 31" src="https://user-images.githubusercontent.com/394889/60829181-37b8b280-a169-11e9-9b8b-d9b6863bb887.png">

TBR @cyanglaz 