### PR TITLE
Add braces so that analyzer and formatter will both accept a single-line if statement

### DIFF
--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -121,7 +121,9 @@ class VersionCheckCommand extends PluginCommand {
             await gitVersionFinder.getPackageVersion(pubspecPath, baseSha);
         final Version headVersion =
             await gitVersionFinder.getPackageVersion(pubspecPath, 'HEAD');
-        if (headVersion == null) continue; // Example apps don't have versions
+        if (headVersion == null) {
+          continue; // Example apps don't have versions
+        }
 
         final Map<Version, NextVersionType> allowedNextVersions =
             getAllowedNextVersions(masterVersion, headVersion);


### PR DESCRIPTION
As discussed in #41, it seems like the Cirrus CI is showing some false passing results in PRs when the formatter/analyzer tests are actually failing. Not sure way, but anyway this fixes the build. I think there's no need to push a package update as it's a formatting-only change.