### PR TITLE
Use java when running flutter create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.19+2
+
+- Use java as language when calling `flutter create`.
+
 ## v.0.0.19+1
 
 - Rename command for `CreateAllPluginsAppCommand`.

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -53,6 +53,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
         '--template=app',
         '--project-name=all_plugins',
         '--androidx',
+        '--android-language=java',
         './all_plugins',
       ],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.19+1
+version: 0.0.19+2
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
The default language for new Flutter projects seems to have switched to `kotlin` from `java`. We now get build errors when running the build_all_plugins_test. In this PR, I'm changing the `flutter create` command to specify java so our CI in the flutter/plugins repo will become green for the time being.

```
You are building a fat APK that includes binaries for android-arm, android-arm64.
If you are deploying the app to the Play Store, it's recommended to use app bundles or split the APK to reduce the APK size.
    To generate an app bundle, run:
        flutter build appbundle --target-platform android-arm,android-arm64
        Learn more on: https://developer.android.com/guide/app-bundle
    To split the APKs per ABI, run:
        flutter build apk --target-platform android-arm,android-arm64 --split-per-abi
        Learn more on:  https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split
Initializing gradle...                                              0.8s
Resolving dependencies...                                       
* Error running Gradle:
ProcessException: Process "/tmp/cirrus-ci-build/all_plugins/android/gradlew" exited abnormally:
> Configure project :app
WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
WARNING: API 'variant.getMergeAssets()' is obsolete and has been replaced with 'variant.getMergeAssetsProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getMergeAssets(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
WARNING: API 'variantOutput.getProcessResources()' is obsolete and has been replaced with 'variantOutput.getProcessResourcesProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variantOutput.getProcessResources(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
         *********************************************************
WARNING: This version of android_alarm_manager will break your Android build if it or its dependencies aren't compatible with AndroidX.
         See https://goo.gl/CP92wY for more information on the problem and how to fix it.
         This warning prints for all Android build failures. The real root cause of the error may be unrelated.
         *********************************************************
FAILURE: Build failed with an exception.
* What went wrong:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.0 and higher.
The following dependencies do not satisfy the required version:
root project 'android' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.71
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 1s
  Command: /tmp/cirrus-ci-build/all_plugins/android/gradlew app:properties
Please review your Gradle project setup in the android/ folder.
Failed to build release all_plugins app.
```