### PR TITLE
Use package:file for file I/O for testability

### DIFF
--- a/.dart_tool/pub/bin/sdk-version
+++ b/.dart_tool/pub/bin/sdk-version
@@ -1,1 +1,0 @@
-2.5.0-edge.3d578c70371757638bab3cb0ed5b5f92cb6dd8bc

--- a/.dart_tool/pub/bin/sdk-version
+++ b/.dart_tool/pub/bin/sdk-version
@@ -1,0 +1,1 @@
+2.5.0-edge.3d578c70371757638bab3cb0ed5b5f92cb6dd8bc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.19+3
+
+- Use `package:file` for file I/O.
+
 ## v.0.0.19+2
 
 - Use java as language when calling `flutter create`.

--- a/lib/src/analyze_command.dart
+++ b/lib/src/analyze_command.dart
@@ -3,14 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
+import 'package:file/file.dart' as fs;
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class AnalyzeCommand extends PluginCommand {
-  AnalyzeCommand(Directory packagesDir) : super(packagesDir);
+  AnalyzeCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem);
 
   @override
   final String name = 'analyze';
@@ -26,8 +27,8 @@ class AnalyzeCommand extends PluginCommand {
     await runAndStream('pub', <String>['global', 'activate', 'tuneup'],
         workingDir: packagesDir, exitOnError: true);
 
-    await for (Directory package in getPackages()) {
-      if (isFlutterPackage(package)) {
+    await for (fs.Directory package in getPackages()) {
+      if (isFlutterPackage(package, fileSystem)) {
         await runAndStream('flutter', <String>['packages', 'get'],
             workingDir: package, exitOnError: true);
       } else {
@@ -37,7 +38,7 @@ class AnalyzeCommand extends PluginCommand {
     }
 
     final List<String> failingPackages = <String>[];
-    await for (Directory package in getPlugins()) {
+    await for (fs.Directory package in getPlugins()) {
       final int exitCode = await runAndStream(
           'pub', <String>['global', 'run', 'tuneup', 'check'],
           workingDir: package);

--- a/lib/src/analyze_command.dart
+++ b/lib/src/analyze_command.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class AnalyzeCommand extends PluginCommand {
-  AnalyzeCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  AnalyzeCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem);
 
   @override
@@ -27,7 +27,7 @@ class AnalyzeCommand extends PluginCommand {
     await runAndStream('pub', <String>['global', 'activate', 'tuneup'],
         workingDir: packagesDir, exitOnError: true);
 
-    await for (fs.Directory package in getPackages()) {
+    await for (Directory package in getPackages()) {
       if (isFlutterPackage(package, fileSystem)) {
         await runAndStream('flutter', <String>['packages', 'get'],
             workingDir: package, exitOnError: true);
@@ -38,7 +38,7 @@ class AnalyzeCommand extends PluginCommand {
     }
 
     final List<String> failingPackages = <String>[];
-    await for (fs.Directory package in getPlugins()) {
+    await for (Directory package in getPlugins()) {
       final int exitCode = await runAndStream(
           'pub', <String>['global', 'run', 'tuneup', 'check'],
           workingDir: package);

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:io' as io;
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class BuildExamplesCommand extends PluginCommand {
-  BuildExamplesCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  BuildExamplesCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addFlag('ipa', defaultsTo: io.Platform.isMacOS);
     argParser.addFlag('apk');

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -3,15 +3,17 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
+import 'package:file/file.dart' as fs;
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class BuildExamplesCommand extends PluginCommand {
-  BuildExamplesCommand(Directory packagesDir) : super(packagesDir) {
-    argParser.addFlag('ipa', defaultsTo: Platform.isMacOS);
+  BuildExamplesCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem) {
+    argParser.addFlag('ipa', defaultsTo: io.Platform.isMacOS);
     argParser.addFlag('apk');
   }
 
@@ -33,7 +35,7 @@ class BuildExamplesCommand extends PluginCommand {
 
     checkSharding();
     final List<String> failingPackages = <String>[];
-    await for (Directory example in getExamples()) {
+    await for (io.Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
 

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -7,18 +7,18 @@ import 'dart:io' as io;
 import 'dart:math';
 
 import 'package:args/command_runner.dart';
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 /// Returns whether the given directory contains a Flutter package.
-bool isFlutterPackage(fs.FileSystemEntity entity, fs.FileSystem fileSystem) {
-  if (entity == null || entity is! fs.Directory) {
+bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
+  if (entity == null || entity is! Directory) {
     return false;
   }
 
   try {
-    final fs.File pubspecFile =
+    final File pubspecFile =
         fileSystem.file(p.join(entity.path, 'pubspec.yaml'));
     final YamlMap pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
     final YamlMap dependencies = pubspecYaml['dependencies'];
@@ -26,7 +26,7 @@ bool isFlutterPackage(fs.FileSystemEntity entity, fs.FileSystem fileSystem) {
       return false;
     }
     return dependencies.containsKey('flutter');
-  } on fs.FileSystemException {
+  } on FileSystemException {
     return false;
   } on YamlException {
     return false;
@@ -69,12 +69,12 @@ abstract class PluginCommand extends Command<Null> {
   static const String _shardCountArg = 'shardCount';
 
   /// The directory containing the plugin packages.
-  final fs.Directory packagesDir;
+  final Directory packagesDir;
 
   /// The file system.
   ///
   /// This can be overridden for testing.
-  final fs.FileSystem fileSystem;
+  final FileSystem fileSystem;
 
   int _shardIndex;
   int _shardCount;
@@ -115,14 +115,13 @@ abstract class PluginCommand extends Command<Null> {
 
   /// Returns the root Dart package folders of the plugins involved in this
   /// command execution.
-  Stream<fs.Directory> getPlugins() async* {
+  Stream<Directory> getPlugins() async* {
     // To avoid assuming consistency of `Directory.list` across command
     // invocations, we collect and sort the plugin folders before sharding.
     // This is considered an implementation detail which is why the API still
     // uses streams.
-    final List<fs.Directory> allPlugins = await _getAllPlugins().toList();
-    allPlugins
-        .sort((fs.Directory d1, fs.Directory d2) => d1.path.compareTo(d2.path));
+    final List<Directory> allPlugins = await _getAllPlugins().toList();
+    allPlugins.sort((Directory d1, Directory d2) => d1.path.compareTo(d2.path));
     // Sharding 10 elements into 3 shards should yield shard sizes 4, 4, 2.
     // Sharding  9 elements into 3 shards should yield shard sizes 3, 3, 3.
     // Sharding  2 elements into 3 shards should yield shard sizes 1, 1, 0.
@@ -130,106 +129,78 @@ abstract class PluginCommand extends Command<Null> {
         (allPlugins.length % shardCount == 0 ? 0 : 1);
     final int start = min(shardIndex * shardSize, allPlugins.length);
     final int end = min(start + shardSize, allPlugins.length);
-    for (fs.Directory plugin in allPlugins.sublist(start, end)) {
+    for (Directory plugin in allPlugins.sublist(start, end)) {
       yield plugin;
     }
   }
 
-  /// Returns the root Dart package folders of the plugins involved in this
-  /// command execution, assuming there is only one shard.
-  ///
-  /// Plugin packages can exist in one of two places relative to the packages
-  /// directory.
-  ///
-  /// 1. As a Dart package in a directory which is a direct child of the
-  ///    packages directory. This is a plugin where all of the implementations
-  ///    exist in a single Dart package.
-  /// 2. Several plugin packages may live in a directory which is a direct
-  ///    child of the packages directory. This directory groups several Dart
-  ///    packages which implement a single plugin. This directory contains a
-  ///    "client library" package, which declares the API for the plugin, as
-  ///    well as one or more platform-specific implementations.
-  Stream<fs.Directory> _getAllPlugins() async* {
+  Stream<Directory> _getAllPlugins() {
     final Set<String> packages = new Set<String>.from(argResults[_pluginsArg]);
-    await for (fs.FileSystemEntity entity
-        in packagesDir.list(followLinks: false)) {
-      // A top-level Dart package is a plugin package.
-      if (_isDartPackage(entity)) {
-        if (packages.isEmpty || packages.contains(p.basename(entity.path))) {
-          yield entity;
-        }
-      } else if (entity is fs.Directory) {
-        // Look for Dart packages under this top-level directory.
-        await for (fs.FileSystemEntity subdir
-            in entity.list(followLinks: false)) {
-          if (_isDartPackage(subdir)) {
-            if (packages.isEmpty ||
-                packages.contains(p.basename(subdir.path))) {
-              yield subdir;
-            }
-          }
-        }
-      }
-    }
+    return packagesDir
+        .list(followLinks: false)
+        .where(_isDartPackage)
+        .where((FileSystemEntity entity) =>
+            packages.isEmpty || packages.contains(p.basename(entity.path)))
+        .cast<Directory>();
   }
 
   /// Returns the example Dart package folders of the plugins involved in this
   /// command execution.
-  Stream<fs.Directory> getExamples() =>
-      getPlugins().expand<fs.Directory>(_getExamplesForPlugin);
+  Stream<Directory> getExamples() =>
+      getPlugins().expand<Directory>(_getExamplesForPlugin);
 
   /// Returns all Dart package folders (typically, plugin + example) of the
   /// plugins involved in this command execution.
-  Stream<fs.Directory> getPackages() async* {
-    await for (fs.Directory plugin in getPlugins()) {
+  Stream<Directory> getPackages() async* {
+    await for (Directory plugin in getPlugins()) {
       yield plugin;
       yield* plugin
           .list(recursive: true, followLinks: false)
           .where(_isDartPackage)
-          .cast<fs.Directory>();
+          .cast<Directory>();
     }
   }
 
   /// Returns the files contained, recursively, within the plugins
   /// involved in this command execution.
-  Stream<fs.File> getFiles() {
-    return getPlugins().asyncExpand<fs.File>((fs.Directory folder) => folder
+  Stream<File> getFiles() {
+    return getPlugins().asyncExpand<File>((Directory folder) => folder
         .list(recursive: true, followLinks: false)
-        .where((fs.FileSystemEntity entity) => entity is fs.File)
-        .cast<fs.File>());
+        .where((FileSystemEntity entity) => entity is File)
+        .cast<File>());
   }
 
   /// Returns whether the specified entity is a directory containing a
   /// `pubspec.yaml` file.
-  bool _isDartPackage(fs.FileSystemEntity entity) {
-    return entity is fs.Directory &&
+  bool _isDartPackage(FileSystemEntity entity) {
+    return entity is Directory &&
         fileSystem.file(p.join(entity.path, 'pubspec.yaml')).existsSync();
   }
 
   /// Returns the example Dart packages contained in the specified plugin, or
   /// an empty List, if the plugin has no examples.
-  Iterable<fs.Directory> _getExamplesForPlugin(fs.Directory plugin) {
-    final fs.Directory exampleFolder =
+  Iterable<Directory> _getExamplesForPlugin(Directory plugin) {
+    final Directory exampleFolder =
         fileSystem.directory(p.join(plugin.path, 'example'));
     if (!exampleFolder.existsSync()) {
-      return <fs.Directory>[];
+      return <Directory>[];
     }
     if (isFlutterPackage(exampleFolder, fileSystem)) {
-      return <fs.Directory>[exampleFolder];
+      return <Directory>[exampleFolder];
     }
     // Only look at the subdirectories of the example directory if the example
     // directory itself is not a Dart package, and only look one level below the
     // example directory for other dart packages.
     return exampleFolder
         .listSync()
-        .where((fs.FileSystemEntity entity) =>
-            isFlutterPackage(entity, fileSystem))
-        .cast<fs.Directory>();
+        .where(
+            (FileSystemEntity entity) => isFlutterPackage(entity, fileSystem))
+        .cast<Directory>();
   }
 }
 
 Future<int> runAndStream(String executable, List<String> args,
-    {fs.Directory workingDir, bool exitOnError: false}) async {
+    {Directory workingDir, bool exitOnError: false}) async {
   final io.Process process = await io.Process.start(executable, args,
       workingDirectory: workingDir?.path);
   io.stdout.addStream(process.stdout);
@@ -244,7 +215,7 @@ Future<int> runAndStream(String executable, List<String> args,
 }
 
 Future<io.ProcessResult> runAndExitOnError(String executable, List<String> args,
-    {fs.Directory workingDir, bool exitOnError: false}) async {
+    {Directory workingDir, bool exitOnError: false}) async {
   final io.ProcessResult result = await io.Process.run(executable, args,
       workingDirectory: workingDir?.path);
   if (result.exitCode != 0) {
@@ -257,7 +228,7 @@ Future<io.ProcessResult> runAndExitOnError(String executable, List<String> args,
 }
 
 String _getErrorString(String executable, List<String> args,
-    {fs.Directory workingDir}) {
+    {Directory workingDir}) {
   final String workdir = workingDir == null ? '' : ' in ${workingDir.path}';
   return 'ERROR: Unable to execute "$executable ${args.join(' ')}"$workdir.';
 }

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' as io;
 
+import 'package:file/file.dart' as fs;
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -12,7 +13,8 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'common.dart';
 
 class CreateAllPluginsAppCommand extends PluginCommand {
-  CreateAllPluginsAppCommand(Directory packagesDir) : super(packagesDir) {
+  CreateAllPluginsAppCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem) {
     argParser.addMultiOption(
       excludeOption,
       abbr: 'e',
@@ -46,7 +48,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<int> _createPlugin() async {
-    final ProcessResult result = Process.runSync(
+    final io.ProcessResult result = io.Process.runSync(
       'flutter',
       <String>[
         'create',
@@ -64,7 +66,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateProjectGradle() async {
-    final File gradleFile = File(p.join(
+    final fs.File gradleFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'build.gradle',
@@ -81,7 +83,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateAppGradle() async {
-    final File gradleFile = File(p.join(
+    final fs.File gradleFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'app',
@@ -106,7 +108,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateManifest() async {
-    final File manifestFile = File(p.join(
+    final fs.File manifestFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'app',
@@ -153,7 +155,8 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       },
     );
 
-    final File pubspecFile = new File(p.join('all_plugins', 'pubspec.yaml'));
+    final fs.File pubspecFile =
+        fileSystem.file(p.join('all_plugins', 'pubspec.yaml'));
     pubspecFile.writeAsStringSync(_pubspecToString(pubspec));
   }
 
@@ -161,13 +164,14 @@ class CreateAllPluginsAppCommand extends PluginCommand {
     final Map<String, PathDependency> pathDependencies =
         <String, PathDependency>{};
 
-    await for (Directory package in getPlugins()) {
+    await for (fs.Directory package in getPlugins()) {
       final String pluginName = package.path.split('/').last;
       if (argResults[excludeOption].contains(pluginName)) {
         continue;
       }
 
-      final File pubspecFile = File(p.join(package.path, 'pubspec.yaml'));
+      final fs.File pubspecFile =
+          fileSystem.file(p.join(package.path, 'pubspec.yaml'));
       final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
 
       if (pubspec.publishTo != 'none') {

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io' as io;
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -13,7 +13,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'common.dart';
 
 class CreateAllPluginsAppCommand extends PluginCommand {
-  CreateAllPluginsAppCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  CreateAllPluginsAppCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addMultiOption(
       excludeOption,
@@ -66,7 +66,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateProjectGradle() async {
-    final fs.File gradleFile = fileSystem.file(p.join(
+    final File gradleFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'build.gradle',
@@ -83,7 +83,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateAppGradle() async {
-    final fs.File gradleFile = fileSystem.file(p.join(
+    final File gradleFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'app',
@@ -108,7 +108,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _updateManifest() async {
-    final fs.File manifestFile = fileSystem.file(p.join(
+    final File manifestFile = fileSystem.file(p.join(
       'all_plugins',
       'android',
       'app',
@@ -155,7 +155,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       },
     );
 
-    final fs.File pubspecFile =
+    final File pubspecFile =
         fileSystem.file(p.join('all_plugins', 'pubspec.yaml'));
     pubspecFile.writeAsStringSync(_pubspecToString(pubspec));
   }
@@ -164,13 +164,13 @@ class CreateAllPluginsAppCommand extends PluginCommand {
     final Map<String, PathDependency> pathDependencies =
         <String, PathDependency>{};
 
-    await for (fs.Directory package in getPlugins()) {
+    await for (Directory package in getPlugins()) {
       final String pluginName = package.path.split('/').last;
       if (argResults[excludeOption].contains(pluginName)) {
         continue;
       }
 
-      final fs.File pubspecFile =
+      final File pubspecFile =
           fileSystem.file(p.join(package.path, 'pubspec.yaml'));
       final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
 

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -6,13 +6,13 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class DriveExamplesCommand extends PluginCommand {
-  DriveExamplesCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  DriveExamplesCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem);
 
   @override
@@ -29,17 +29,17 @@ class DriveExamplesCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingTests = <String>[];
-    await for (fs.Directory example in getExamples()) {
+    await for (Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
-      final fs.Directory driverTests =
+      final Directory driverTests =
           fileSystem.directory(p.join(example.path, 'test_driver'));
       if (!driverTests.existsSync()) {
         // No driver tests available for this example
         continue;
       }
       // Look for driver tests ending in _test.dart in test_driver/
-      await for (fs.FileSystemEntity test in driverTests.list()) {
+      await for (FileSystemEntity test in driverTests.list()) {
         final String driverTestName =
             p.relative(test.path, from: driverTests.path);
         if (!driverTestName.endsWith("_test.dart")) {

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -4,14 +4,16 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
+import 'package:file/file.dart' as fs;
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class DriveExamplesCommand extends PluginCommand {
-  DriveExamplesCommand(Directory packagesDir) : super(packagesDir);
+  DriveExamplesCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem);
 
   @override
   final String name = 'drive-examples';
@@ -27,17 +29,17 @@ class DriveExamplesCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingTests = <String>[];
-    await for (Directory example in getExamples()) {
+    await for (fs.Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
-      final Directory driverTests =
-          Directory(p.join(example.path, 'test_driver'));
+      final fs.Directory driverTests =
+          fileSystem.directory(p.join(example.path, 'test_driver'));
       if (!driverTests.existsSync()) {
         // No driver tests available for this example
         continue;
       }
       // Look for driver tests ending in _test.dart in test_driver/
-      await for (FileSystemEntity test in driverTests.list()) {
+      await for (fs.FileSystemEntity test in driverTests.list()) {
         final String driverTestName =
             p.relative(test.path, from: driverTests.path);
         if (!driverTestName.endsWith("_test.dart")) {
@@ -49,17 +51,21 @@ class DriveExamplesCommand extends PluginCommand {
           '.dart',
         );
         String deviceTestPath = p.join('test', deviceTestName);
-        if (!File(p.join(example.path, deviceTestPath)).existsSync()) {
+        if (!fileSystem
+            .file(p.join(example.path, deviceTestPath))
+            .existsSync()) {
           // If the app isn't in test/ folder, look in test_driver/ instead.
           deviceTestPath = p.join('test_driver', deviceTestName);
         }
-        if (!File(p.join(example.path, deviceTestPath)).existsSync()) {
+        if (!fileSystem
+            .file(p.join(example.path, deviceTestPath))
+            .existsSync()) {
           print('Unable to find an application for $driverTestName to drive');
           failingTests.add(p.join(example.path, driverTestName));
           continue;
         }
         print('RUNNING DRIVER TEST for ${p.join(packageName, deviceTestPath)}');
-        final Process process = await Process.start(
+        final io.Process process = await io.Process.start(
           'flutter',
           <String>['drive', deviceTestPath],
           workingDirectory: example.path,
@@ -74,9 +80,9 @@ class DriveExamplesCommand extends PluginCommand {
           if (data.contains('All tests passed!')) {
             testsPassed = true;
           }
-          stdout.write(data);
+          io.stdout.write(data);
         });
-        stderr.addStream(process.stderr);
+        io.stderr.addStream(process.stderr);
         if (await process.exitCode != 0 || !testsPassed) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:io' as io;
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class FirebaseTestLabCommand extends PluginCommand {
-  FirebaseTestLabCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  FirebaseTestLabCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addOption(
       'project',
@@ -67,8 +67,8 @@ class FirebaseTestLabCommand extends PluginCommand {
   @override
   Future<Null> run() async {
     checkSharding();
-    final Stream<fs.Directory> examplesWithTests = getExamples().where(
-        (fs.Directory d) =>
+    final Stream<Directory> examplesWithTests = getExamples().where(
+        (Directory d) =>
             isFlutterPackage(d, fileSystem) &&
             fileSystem
                 .directory(
@@ -77,11 +77,11 @@ class FirebaseTestLabCommand extends PluginCommand {
 
     final List<String> failingPackages = <String>[];
     final List<String> missingFlutterBuild = <String>[];
-    await for (fs.Directory example in examplesWithTests) {
+    await for (Directory example in examplesWithTests) {
       // TODO(jackson): We should also support testing lib/main.dart for
       // running non-Dart instrumentation tests.
       // See https://github.com/flutter/flutter/issues/38983
-      final fs.Directory testsDir =
+      final Directory testsDir =
           fileSystem.directory(p.join(example.path, 'test_instrumentation'));
       if (!testsDir.existsSync()) {
         continue;
@@ -91,7 +91,7 @@ class FirebaseTestLabCommand extends PluginCommand {
           p.relative(example.path, from: packagesDir.path);
       print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
 
-      final fs.Directory androidDirectory =
+      final Directory androidDirectory =
           fileSystem.directory(p.join(example.path, 'android'));
       if (!fileSystem
           .file(p.join(androidDirectory.path, _gradleWrapper))
@@ -117,7 +117,7 @@ class FirebaseTestLabCommand extends PluginCommand {
         continue;
       }
 
-      for (fs.File test in testsDir.listSync()) {
+      for (File test in testsDir.listSync()) {
         exitCode = await runAndStream(
             p.join(androidDirectory.path, _gradleWrapper),
             <String>[

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:quiver/iterables.dart';
@@ -17,7 +17,7 @@ const String _googleFormatterUrl =
     'https://github.com/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar';
 
 class FormatCommand extends PluginCommand {
-  FormatCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  FormatCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addFlag('travis', hide: true);
     argParser.addOption('clang-format',
@@ -117,15 +117,15 @@ class FormatCommand extends PluginCommand {
 
   Future<List<String>> _getFilesWithExtension(String extension) async =>
       getFiles()
-          .where((fs.File file) => p.extension(file.path) == extension)
-          .map((fs.File file) => file.path)
+          .where((File file) => p.extension(file.path) == extension)
+          .map((File file) => file.path)
           .toList();
 
   Future<String> _getGoogleFormatterPath() async {
     final String javaFormatterPath = p.join(
         p.dirname(p.fromUri(io.Platform.script)),
         'google-java-format-1.3-all-deps.jar');
-    final fs.File javaFormatterFile = fileSystem.file(javaFormatterPath);
+    final File javaFormatterFile = fileSystem.file(javaFormatterPath);
 
     if (!javaFormatterFile.existsSync()) {
       print('Downloading Google Java Format...');

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' as io;
 
+import 'package:file/file.dart' as fs;
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:quiver/iterables.dart';
@@ -16,7 +17,8 @@ const String _googleFormatterUrl =
     'https://github.com/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar';
 
 class FormatCommand extends PluginCommand {
-  FormatCommand(Directory packagesDir) : super(packagesDir) {
+  FormatCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem) {
     argParser.addFlag('travis', hide: true);
     argParser.addOption('clang-format',
         defaultsTo: 'clang-format',
@@ -50,7 +52,7 @@ class FormatCommand extends PluginCommand {
   }
 
   Future<bool> _didModifyAnything() async {
-    final ProcessResult modifiedFiles = await runAndExitOnError(
+    final io.ProcessResult modifiedFiles = await runAndExitOnError(
         'git', <String>['ls-files', '--modified'],
         workingDir: packagesDir);
 
@@ -71,7 +73,8 @@ class FormatCommand extends PluginCommand {
         'this command into your terminal:');
 
     print('patch -p1 <<DONE');
-    final ProcessResult diff = await runAndExitOnError('git', <String>['diff'],
+    final io.ProcessResult diff = await runAndExitOnError(
+        'git', <String>['diff'],
         workingDir: packagesDir);
     print(diff.stdout);
     print('DONE');
@@ -114,15 +117,15 @@ class FormatCommand extends PluginCommand {
 
   Future<List<String>> _getFilesWithExtension(String extension) async =>
       getFiles()
-          .where((File file) => p.extension(file.path) == extension)
-          .map((File file) => file.path)
+          .where((fs.File file) => p.extension(file.path) == extension)
+          .map((fs.File file) => file.path)
           .toList();
 
   Future<String> _getGoogleFormatterPath() async {
     final String javaFormatterPath = p.join(
-        p.dirname(p.fromUri(Platform.script)),
+        p.dirname(p.fromUri(io.Platform.script)),
         'google-java-format-1.3-all-deps.jar');
-    final File javaFormatterFile = new File(javaFormatterPath);
+    final fs.File javaFormatterFile = fileSystem.file(javaFormatterPath);
 
     if (!javaFormatterFile.existsSync()) {
       print('Downloading Google Java Format...');

--- a/lib/src/java_test_command.dart
+++ b/lib/src/java_test_command.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class JavaTestCommand extends PluginCommand {
-  JavaTestCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  JavaTestCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem);
 
   @override
@@ -26,8 +26,8 @@ class JavaTestCommand extends PluginCommand {
   @override
   Future<Null> run() async {
     checkSharding();
-    final Stream<fs.Directory> examplesWithTests = getExamples().where(
-        (fs.Directory d) =>
+    final Stream<Directory> examplesWithTests = getExamples().where(
+        (Directory d) =>
             isFlutterPackage(d, fileSystem) &&
             fileSystem
                 .directory(p.join(d.path, 'android', 'app', 'src', 'test'))
@@ -35,12 +35,12 @@ class JavaTestCommand extends PluginCommand {
 
     final List<String> failingPackages = <String>[];
     final List<String> missingFlutterBuild = <String>[];
-    await for (fs.Directory example in examplesWithTests) {
+    await for (Directory example in examplesWithTests) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
       print('\nRUNNING JAVA TESTS for $packageName');
 
-      final fs.Directory androidDirectory =
+      final Directory androidDirectory =
           fileSystem.directory(p.join(example.path, 'android'));
       if (!fileSystem
           .file(p.join(androidDirectory.path, _gradleWrapper))

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 
 import 'common.dart';
 
 class ListCommand extends PluginCommand {
-  ListCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  ListCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addOption(
       _type,
@@ -36,22 +36,22 @@ class ListCommand extends PluginCommand {
     checkSharding();
     switch (argResults[_type]) {
       case _plugin:
-        await for (fs.Directory package in getPlugins()) {
+        await for (Directory package in getPlugins()) {
           print(package.path);
         }
         break;
       case _example:
-        await for (fs.Directory package in getExamples()) {
+        await for (Directory package in getExamples()) {
           print(package.path);
         }
         break;
       case _package:
-        await for (fs.Directory package in getPackages()) {
+        await for (Directory package in getPackages()) {
           print(package.path);
         }
         break;
       case _file:
-        await for (fs.File file in getFiles()) {
+        await for (File file in getFiles()) {
           print(file.path);
         }
         break;

--- a/lib/src/list_command.dart
+++ b/lib/src/list_command.dart
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+
+import 'package:file/file.dart' as fs;
 
 import 'common.dart';
 
 class ListCommand extends PluginCommand {
-  ListCommand(Directory packagesDir) : super(packagesDir) {
+  ListCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+      : super(packagesDir, fileSystem) {
     argParser.addOption(
       _type,
       defaultsTo: _plugin,
@@ -34,22 +36,22 @@ class ListCommand extends PluginCommand {
     checkSharding();
     switch (argResults[_type]) {
       case _plugin:
-        await for (Directory package in getPlugins()) {
+        await for (fs.Directory package in getPlugins()) {
           print(package.path);
         }
         break;
       case _example:
-        await for (Directory package in getExamples()) {
+        await for (fs.Directory package in getExamples()) {
           print(package.path);
         }
         break;
       case _package:
-        await for (Directory package in getPackages()) {
+        await for (fs.Directory package in getPackages()) {
           print(package.path);
         }
         break;
       case _file:
-        await for (File file in getFiles()) {
+        await for (fs.File file in getFiles()) {
           print(file.path);
         }
         break;

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
+import 'package:file/file.dart' as fs;
+import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 
 import 'analyze_command.dart';
@@ -20,34 +22,36 @@ import 'test_command.dart';
 import 'version_check_command.dart';
 
 void main(List<String> args) {
-  Directory packagesDir =
-      new Directory(p.join(Directory.current.path, 'packages'));
+  final fs.FileSystem fileSystem = LocalFileSystem();
+
+  fs.Directory packagesDir =
+      fileSystem.directory(p.join(fileSystem.currentDirectory.path, 'packages'));
 
   if (!packagesDir.existsSync()) {
-    if (p.basename(Directory.current.path) == 'packages') {
-      packagesDir = Directory.current;
+    if (p.basename(fileSystem.currentDirectory.path) == 'packages') {
+      packagesDir = fileSystem.currentDirectory;
     } else {
       print('Error: Cannot find a "packages" sub-directory');
-      exit(1);
+      io.exit(1);
     }
   }
 
   final CommandRunner<Null> commandRunner = new CommandRunner<Null>(
       'pub global run flutter_plugin_tools',
       'Productivity utils for hosting multiple plugins within one repository.')
-    ..addCommand(new TestCommand(packagesDir))
-    ..addCommand(new AnalyzeCommand(packagesDir))
-    ..addCommand(new FormatCommand(packagesDir))
-    ..addCommand(new BuildExamplesCommand(packagesDir))
-    ..addCommand(new DriveExamplesCommand(packagesDir))
-    ..addCommand(new FirebaseTestLabCommand(packagesDir))
-    ..addCommand(new JavaTestCommand(packagesDir))
-    ..addCommand(new ListCommand(packagesDir))
-    ..addCommand(new VersionCheckCommand(packagesDir))
-    ..addCommand(new CreateAllPluginsAppCommand(packagesDir));
+    ..addCommand(new TestCommand(packagesDir, fileSystem))
+    ..addCommand(new AnalyzeCommand(packagesDir, fileSystem))
+    ..addCommand(new FormatCommand(packagesDir, fileSystem))
+    ..addCommand(new BuildExamplesCommand(packagesDir, fileSystem))
+    ..addCommand(new DriveExamplesCommand(packagesDir, fileSystem))
+    ..addCommand(new FirebaseTestLabCommand(packagesDir, fileSystem))
+    ..addCommand(new JavaTestCommand(packagesDir, fileSystem))
+    ..addCommand(new ListCommand(packagesDir, fileSystem))
+    ..addCommand(new VersionCheckCommand(packagesDir, fileSystem))
+    ..addCommand(new CreateAllPluginsAppCommand(packagesDir, fileSystem));
 
   commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e;
-    exit(toolExit.exitCode);
+    io.exit(toolExit.exitCode);
   }, test: (Object e) => e is ToolExit);
 }

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -22,10 +22,10 @@ import 'test_command.dart';
 import 'version_check_command.dart';
 
 void main(List<String> args) {
-  final fs.FileSystem fileSystem = LocalFileSystem();
+  final fs.FileSystem fileSystem = const LocalFileSystem();
 
-  fs.Directory packagesDir =
-      fileSystem.directory(p.join(fileSystem.currentDirectory.path, 'packages'));
+  fs.Directory packagesDir = fileSystem
+      .directory(p.join(fileSystem.currentDirectory.path, 'packages'));
 
   if (!packagesDir.existsSync()) {
     if (p.basename(fileSystem.currentDirectory.path) == 'packages') {

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -5,7 +5,7 @@
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 
@@ -22,9 +22,9 @@ import 'test_command.dart';
 import 'version_check_command.dart';
 
 void main(List<String> args) {
-  final fs.FileSystem fileSystem = const LocalFileSystem();
+  final FileSystem fileSystem = const LocalFileSystem();
 
-  fs.Directory packagesDir = fileSystem
+  Directory packagesDir = fileSystem
       .directory(p.join(fileSystem.currentDirectory.path, 'packages'));
 
   if (!packagesDir.existsSync()) {

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -4,13 +4,13 @@
 
 import 'dart:async';
 
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
 class TestCommand extends PluginCommand {
-  TestCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  TestCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem);
 
   @override
@@ -24,7 +24,7 @@ class TestCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingPackages = <String>[];
-    await for (fs.Directory packageDir in getPackages()) {
+    await for (Directory packageDir in getPackages()) {
       final String packageName =
           p.relative(packageDir.path, from: packagesDir.path);
       if (!fileSystem.directory(p.join(packageDir.path, 'test')).existsSync()) {

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -7,7 +7,7 @@ import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 import 'package:colorize/colorize.dart';
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:git/git.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -86,7 +86,7 @@ Map<Version, NextVersionType> getAllowedNextVersions(
 }
 
 class VersionCheckCommand extends PluginCommand {
-  VersionCheckCommand(fs.Directory packagesDir, fs.FileSystem fileSystem)
+  VersionCheckCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
     argParser.addOption(_kBaseSha);
   }
@@ -120,7 +120,7 @@ class VersionCheckCommand extends PluginCommand {
 
     for (final String pubspecPath in changedPubspecs) {
       try {
-        final fs.File pubspecFile = fileSystem.file(pubspecPath);
+        final File pubspecFile = fileSystem.file(pubspecPath);
         final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
 
         if (pubspec.publishTo == 'none') {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   pubspec_parse: "^0.1.4"
   test: ^1.6.4
   meta: ^1.1.7
+  file: ^5.0.10
 
 environment:
   sdk: ">=1.8.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.19+2
+version: 0.0.19+3
 
 dependencies:
   args: "^1.4.3"

--- a/test/list_command_test.dart
+++ b/test/list_command_test.dart
@@ -1,12 +1,6 @@
-import 'package:test/test.dart';
-
-import 'dart:async';
-import 'dart:io' as io;
-
 import 'package:args/command_runner.dart';
-import 'package:file/file.dart' as fs;
-import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
+import 'package:test/test.dart';
 
 import 'util.dart';
 

--- a/test/list_command_test.dart
+++ b/test/list_command_test.dart
@@ -1,0 +1,112 @@
+import 'package:test/test.dart';
+
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart' as fs;
+import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/list_command.dart';
+
+import 'util.dart';
+
+void main() {
+  group('$ListCommand', () {
+    CommandRunner runner;
+
+    setUp(() {
+      initializeFakePackages();
+      final ListCommand command = ListCommand(mockPackagesDir, mockFileSystem);
+
+      runner = CommandRunner<Null>('list_test', 'Test for $ListCommand');
+      runner.addCommand(command);
+    });
+
+    test('lists plugins', () async {
+      createFakePlugin('plugin1');
+      createFakePlugin('plugin2');
+
+      List<String> plugins =
+          await runCapturingPrint(runner, <String>['list', '--type=plugin']);
+
+      expect(
+        plugins,
+        orderedEquals(<String>[
+          '/packages/plugin1',
+          '/packages/plugin2',
+        ]),
+      );
+
+      cleanupPackages();
+    });
+
+    test('lists examples', () async {
+      createFakePlugin('plugin1', withSingleExample: true);
+      createFakePlugin('plugin2',
+          withExamples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3');
+
+      List<String> examples =
+          await runCapturingPrint(runner, <String>['list', '--type=example']);
+
+      expect(
+        examples,
+        orderedEquals(<String>[
+          '/packages/plugin1/example',
+          '/packages/plugin2/example/example1',
+          '/packages/plugin2/example/example2',
+        ]),
+      );
+
+      cleanupPackages();
+    });
+
+    test('lists packages', () async {
+      createFakePlugin('plugin1', withSingleExample: true);
+      createFakePlugin('plugin2',
+          withExamples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3');
+
+      List<String> packages =
+          await runCapturingPrint(runner, <String>['list', '--type=package']);
+
+      expect(
+        packages,
+        unorderedEquals(<String>[
+          '/packages/plugin1',
+          '/packages/plugin1/example',
+          '/packages/plugin2',
+          '/packages/plugin2/example/example1',
+          '/packages/plugin2/example/example2',
+          '/packages/plugin3',
+        ]),
+      );
+
+      cleanupPackages();
+    });
+
+    test('lists file', () async {
+      createFakePlugin('plugin1', withSingleExample: true);
+      createFakePlugin('plugin2',
+          withExamples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3');
+
+      List<String> examples =
+          await runCapturingPrint(runner, <String>['list', '--type=file']);
+
+      expect(
+        examples,
+        unorderedEquals(<String>[
+          '/packages/plugin1/pubspec.yaml',
+          '/packages/plugin1/example/pubspec.yaml',
+          '/packages/plugin2/pubspec.yaml',
+          '/packages/plugin2/example/example1/pubspec.yaml',
+          '/packages/plugin2/example/example2/pubspec.yaml',
+          '/packages/plugin3/pubspec.yaml',
+        ]),
+      );
+
+      cleanupPackages();
+    });
+  });
+}

--- a/test/util.dart
+++ b/test/util.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
-import 'package:file/file.dart' as fs;
+import 'package:file/file.dart';
 import 'package:file/memory.dart';
 
-fs.FileSystem mockFileSystem = MemoryFileSystem();
-fs.Directory mockPackagesDir;
+final FileSystem mockFileSystem = MemoryFileSystem();
+Directory mockPackagesDir;
 
 /// Creates a mock packages directory in the mock file system.
 void initializeFakePackages() {
@@ -24,19 +24,19 @@ void createFakePlugin(
   assert(!(withSingleExample && withExamples.isNotEmpty),
       'cannot pass withSingleExample and withExamples simultaneously');
 
-  final fs.Directory pluginDirectory = mockPackagesDir.childDirectory(name)
+  final Directory pluginDirectory = mockPackagesDir.childDirectory(name)
     ..createSync();
   _createFakePubspec(pluginDirectory);
 
   if (withSingleExample) {
-    final fs.Directory exampleDir = pluginDirectory.childDirectory('example')
+    final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     _createFakePubspec(exampleDir);
   } else if (withExamples.isNotEmpty) {
-    final fs.Directory exampleDir = pluginDirectory.childDirectory('example')
+    final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     for (String example in withExamples) {
-      final fs.Directory currentExample = exampleDir.childDirectory(example)
+      final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
       _createFakePubspec(currentExample);
     }
@@ -44,7 +44,7 @@ void createFakePlugin(
 }
 
 /// Creates a `pubspec.yaml` file with a flutter dependency.
-void _createFakePubspec(fs.Directory parent) {
+void _createFakePubspec(Directory parent) {
   parent.childFile('pubspec.yaml').createSync();
   parent.childFile('pubspec.yaml').writeAsStringSync('''
 name: fake_package
@@ -56,7 +56,7 @@ dependencies:
 
 /// Cleans up the mock packages directory, making it an empty directory again.
 void cleanupPackages() {
-  mockPackagesDir.listSync().forEach((fs.FileSystemEntity entity) {
+  mockPackagesDir.listSync().forEach((FileSystemEntity entity) {
     entity.deleteSync(recursive: true);
   });
 }

--- a/test/util.dart
+++ b/test/util.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart' as fs;
+import 'package:file/memory.dart';
+
+fs.FileSystem mockFileSystem = MemoryFileSystem();
+fs.Directory mockPackagesDir;
+
+/// Creates a mock packages directory in the mock file system.
+void initializeFakePackages() {
+  mockPackagesDir = mockFileSystem.currentDirectory.childDirectory('packages');
+  mockPackagesDir.createSync();
+}
+
+/// Creates a plugin package with the given [name] under the mock packages
+/// directory.
+void createFakePlugin(
+  String name, {
+  bool withSingleExample: false,
+  List<String> withExamples: const <String>[],
+}) {
+  assert(!(withSingleExample && withExamples.isNotEmpty),
+      'cannot pass withSingleExample and withExamples simultaneously');
+
+  final fs.Directory pluginDirectory = mockPackagesDir.childDirectory(name)
+    ..createSync();
+  _createFakePubspec(pluginDirectory);
+
+  if (withSingleExample) {
+    final fs.Directory exampleDir = pluginDirectory.childDirectory('example')
+      ..createSync();
+    _createFakePubspec(exampleDir);
+  } else if (withExamples.isNotEmpty) {
+    final fs.Directory exampleDir = pluginDirectory.childDirectory('example')
+      ..createSync();
+    for (String example in withExamples) {
+      final fs.Directory currentExample = exampleDir.childDirectory(example)
+        ..createSync();
+      _createFakePubspec(currentExample);
+    }
+  }
+}
+
+/// Creates a `pubspec.yaml` file with a flutter dependency.
+void _createFakePubspec(fs.Directory parent) {
+  parent.childFile('pubspec.yaml').createSync();
+  parent.childFile('pubspec.yaml').writeAsStringSync('''
+name: fake_package
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+}
+
+/// Cleans up the mock packages directory, making it an empty directory again.
+void cleanupPackages() {
+  mockPackagesDir.listSync().forEach((fs.FileSystemEntity entity) {
+    entity.deleteSync(recursive: true);
+  });
+}
+
+/// Run the command [runner] with the given [args] and return
+/// what was printed.
+Future<List<String>> runCapturingPrint(
+    CommandRunner runner, List<String> args) async {
+  final List<String> prints = <String>[];
+  final ZoneSpecification spec = ZoneSpecification(
+    print: (_, __, ___, String message) {
+      prints.add(message);
+    },
+  );
+  await Zone.current
+      .fork(specification: spec)
+      .run<Future<void>>(() => runner.run(args));
+
+  return prints;
+}


### PR DESCRIPTION
Using package:file allows us to use the real filesystem while
running normally, but a mock filesystem for tests, making further
changes (and existing commands) much easier to test.

This change also adds a test for `ListCommand` as a proof-of-concept.

See flutter/flutter#38986