### PR TITLE
Update flutter_plugin_tools with new test locations

### DIFF
--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -74,8 +74,8 @@ class FirebaseTestLabCommand extends PluginCommand {
         (Directory d) =>
             isFlutterPackage(d, fileSystem) &&
             fileSystem
-                .directory(
-                    p.join(d.path, 'example', 'android', 'app', 'src', 'androidTest'))
+                .directory(p.join(
+                    d.path, 'example', 'android', 'app', 'src', 'androidTest'))
                 .existsSync());
 
     final List<String> failingPackages = <String>[];
@@ -84,7 +84,7 @@ class FirebaseTestLabCommand extends PluginCommand {
       // See https://github.com/flutter/flutter/issues/38983
 
       final Directory exampleDirectory =
-        fileSystem.directory(p.join(package.path, 'example'));
+          fileSystem.directory(p.join(package.path, 'example'));
       final String packageName =
           p.relative(package.path, from: packagesDir.path);
       print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
@@ -126,8 +126,9 @@ class FirebaseTestLabCommand extends PluginCommand {
         continue;
       }
 
-      final List<FileSystemEntity> entities = package.listSync(recursive: true, followLinks: true).toList();
-      for(FileSystemEntity entity in entities) {
+      final List<FileSystemEntity> entities =
+          package.listSync(recursive: true, followLinks: true).toList();
+      for (FileSystemEntity entity in entities) {
         if (!entity.path.endsWith('_e2e.dart')) {
           continue;
         }

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -98,7 +98,7 @@ class FirebaseTestLabCommand extends PluginCommand {
       if (!fileSystem
           .file(p.join(androidDirectory.path, _gradleWrapper))
           .existsSync()) {
-        int exitCode = await runAndStream(
+        int exitCode = await processRunner.runAndStream(
             'flutter',
             <String>[
               'build',

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -96,9 +96,8 @@ class FirebaseTestLabCommand extends PluginCommand {
           .file(p.join(androidDirectory.path, _gradleWrapper))
           .existsSync()) {
         int exitCode = await runAndStream(
-            p.join(androidDirectory.path, _gradleWrapper),
+            'flutter',
             <String>[
-              'flutter',
               'build',
               'apk',
             ],

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -118,7 +118,7 @@ class FirebaseTestLabCommand extends PluginCommand {
       int exitCode = await processRunner.runAndStream(
           p.join(androidDirectory.path, _gradleWrapper),
           <String>[
-            'assembleAndroidTest',
+            'app:assembleAndroidTest',
             '-Pverbose=true',
           ],
           workingDir: androidDirectory);
@@ -137,7 +137,7 @@ class FirebaseTestLabCommand extends PluginCommand {
         exitCode = await processRunner.runAndStream(
             p.join(androidDirectory.path, _gradleWrapper),
             <String>[
-              'assembleDebug',
+              'app:assembleDebug',
               '-Pverbose=true',
               '-Ptarget=${entity.path}'
             ],

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -131,14 +131,21 @@ class FirebaseTestLabCommand extends PluginCommand {
       bool isTestDir(FileSystemEntity dir) {
         return p.basename(dir.path).startsWith('test');
       }
-      final List<FileSystemEntity> testDirs = package.listSync().where(isTestDir).toList();
-      final Directory example = fileSystem.directory(p.join(package.path, 'example'));
+
+      final List<FileSystemEntity> testDirs =
+          package.listSync().where(isTestDir).toList();
+      final Directory example =
+          fileSystem.directory(p.join(package.path, 'example'));
       testDirs.addAll(example.listSync().where(isTestDir).toList());
       for (Directory testDir in testDirs) {
         bool isE2ETest(FileSystemEntity file) {
           return file.path.endsWith('_e2e.dart');
         }
-        List<FileSystemEntity> testFiles = testDir.listSync(recursive: true, followLinks: true).where(isE2ETest).toList();
+
+        List<FileSystemEntity> testFiles = testDir
+            .listSync(recursive: true, followLinks: true)
+            .where(isE2ETest)
+            .toList();
         for (FileSystemEntity test in testFiles) {
           exitCode = await processRunner.runAndStream(
               p.join(androidDirectory.path, _gradleWrapper),

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -142,7 +142,7 @@ class FirebaseTestLabCommand extends PluginCommand {
           return file.path.endsWith('_e2e.dart');
         }
 
-        List<FileSystemEntity> testFiles = testDir
+        final List<FileSystemEntity> testFiles = testDir
             .listSync(recursive: true, followLinks: true)
             .where(isE2ETest)
             .toList();

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -85,8 +85,6 @@ class FirebaseTestLabCommand extends PluginCommand {
 
       final Directory exampleDirectory =
         fileSystem.directory(p.join(package.path, 'example'));
-      final Directory testsDir =
-        fileSystem.directory(p.join(exampleDirectory.path, 'test'));
       final String packageName =
           p.relative(package.path, from: packagesDir.path);
       print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
@@ -98,7 +96,7 @@ class FirebaseTestLabCommand extends PluginCommand {
       if (!fileSystem
           .file(p.join(androidDirectory.path, _gradleWrapper))
           .existsSync()) {
-        int exitCode = await processRunner.runAndStream(
+        final int exitCode = await processRunner.runAndStream(
             'flutter',
             <String>[
               'build',
@@ -128,7 +126,7 @@ class FirebaseTestLabCommand extends PluginCommand {
         continue;
       }
 
-      List<FileSystemEntity> entities = package.listSync(recursive: true, followLinks: true).toList();
+      final List<FileSystemEntity> entities = package.listSync(recursive: true, followLinks: true).toList();
       for(FileSystemEntity entity in entities) {
         if (!entity.path.endsWith('_e2e.dart')) {
           continue;

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -129,7 +129,7 @@ class FirebaseTestLabCommand extends PluginCommand {
       final List<FileSystemEntity> entities =
           package.listSync(recursive: true, followLinks: true).toList();
       for (FileSystemEntity entity in entities) {
-        if (!entity.path.endsWith('_e2e.dart')) {
+        if (!entity.path.contains('/test') || !entity.path.endsWith('_e2e.dart')) {
           continue;
         }
 

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -26,9 +26,14 @@ void main() {
 
     test('runs e2e tests', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['test', 'plugin_test.dart'],
+        <String>['test', 'plugin_e2e.dart'],
+        <String>['should_not_run_e2e.dart'],
         <String>['example', 'test', 'plugin_e2e.dart'],
+        <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
         <String>['example', 'android', 'gradlew'],
+        <String>['example', 'should_not_run_e2e.dart'],
         <String>[
           'example',
           'android',
@@ -67,7 +72,27 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
+                  .split(' '),
+              '/packages/plugin/example/android'),
+          ProcessCall(
+              'gcloud',
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'
+                  .split(' '),
+              '/packages/plugin/example'),
+          ProcessCall(
+              '/packages/plugin/example/android/gradlew',
               'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
+                  .split(' '),
+              '/packages/plugin/example/android'),
+          ProcessCall(
+              'gcloud',
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'
+                  .split(' '),
+              '/packages/plugin/example'),
+          ProcessCall(
+              '/packages/plugin/example/android/gradlew',
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/test/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -11,19 +11,19 @@ void main() {
 
     setUp(() {
       initializeFakePackages();
-      final FirebaseTestLabCommand command = FirebaseTestLabCommand(mockPackagesDir, mockFileSystem, processRunner: mockProcessRunner);
+      final FirebaseTestLabCommand command = FirebaseTestLabCommand(mockPackagesDir, mockFileSystem, processRunner: RecordingProcessRunner());
 
       runner = CommandRunner<Null>('firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
       runner.addCommand(command);
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', withExtraFiles: [
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[ 
         <String>['example', 'test', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
         <String>['example', 'android', 'gradlew'],
         <String>['example', 'android', 'app', 'src', 'androidTest', 'MainActivityTest.java'],
-      ];
+      ]);
 
       List<String> plugins =
           await runCapturingPrint(runner, <String>['firebase-test-lab']);

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -54,7 +54,7 @@ void main() {
         orderedEquals(<ProcessCall>[
           ProcessCall('gcloud', 'auth activate-service-account --key-file=/Users/jackson/gcloud-service-key.json'.split(' '), null),
           ProcessCall('gcloud', '--quiet config set project flutter-infra'.split(' '), null),
-          ProcessCall('/packages/plugin/example/android/gradlew app:assembleAndroidTest', '-Pverbose=true'.split(' '), '/packages/plugin/example/android'),
+          ProcessCall('/packages/plugin/example/android/gradlew', 'app:assembleAndroidTest -Pverbose=true'.split(' '), '/packages/plugin/example/android'),
           ProcessCall('/packages/plugin/example/android/gradlew', 'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'.split(' '), '/packages/plugin/example/android'),
           ProcessCall('gcloud', 'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'.split(' '), '/packages/plugin/example'),
         ]),

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -52,11 +52,27 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('gcloud', 'auth activate-service-account --key-file=/Users/jackson/gcloud-service-key.json'.split(' '), null),
-          ProcessCall('gcloud', '--quiet config set project flutter-infra'.split(' '), null),
-          ProcessCall('/packages/plugin/example/android/gradlew', 'app:assembleAndroidTest -Pverbose=true'.split(' '), '/packages/plugin/example/android'),
-          ProcessCall('/packages/plugin/example/android/gradlew', 'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'.split(' '), '/packages/plugin/example/android'),
-          ProcessCall('gcloud', 'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'.split(' '), '/packages/plugin/example'),
+          ProcessCall(
+              'gcloud',
+              'auth activate-service-account --key-file=/Users/jackson/gcloud-service-key.json'
+                  .split(' '),
+              null),
+          ProcessCall('gcloud',
+              '--quiet config set project flutter-infra'.split(' '), null),
+          ProcessCall(
+              '/packages/plugin/example/android/gradlew',
+              'app:assembleAndroidTest -Pverbose=true'.split(' '),
+              '/packages/plugin/example/android'),
+          ProcessCall(
+              '/packages/plugin/example/android/gradlew',
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
+                  .split(' '),
+              '/packages/plugin/example/android'),
+          ProcessCall(
+              'gcloud',
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'
+                  .split(' '),
+              '/packages/plugin/example'),
         ]),
       );
 

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -11,27 +11,39 @@ void main() {
 
     setUp(() {
       initializeFakePackages();
-      final FirebaseTestLabCommand command = FirebaseTestLabCommand(mockPackagesDir, mockFileSystem, processRunner: RecordingProcessRunner());
+      final FirebaseTestLabCommand command = FirebaseTestLabCommand(
+          mockPackagesDir, mockFileSystem,
+          processRunner: RecordingProcessRunner());
 
-      runner = CommandRunner<Null>('firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
+      runner = CommandRunner<Null>(
+          'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
       runner.addCommand(command);
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[ 
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
         <String>['example', 'android', 'gradlew'],
-        <String>['example', 'android', 'app', 'src', 'androidTest', 'MainActivityTest.java'],
+        <String>[
+          'example',
+          'android',
+          'app',
+          'src',
+          'androidTest',
+          'MainActivityTest.java'
+        ],
       ]);
 
-      List<String> plugins =
+      List<String> output =
           await runCapturingPrint(runner, <String>['firebase-test-lab']);
 
       expect(
-        plugins,
+        output,
         orderedEquals(<String>[
-          'All Firebase Test Lab tests successful!'
+          '\nRUNNING FIREBASE TEST LAB TESTS for plugin',
+          '\n\n',
+          'All Firebase Test Lab tests successful!',
         ]),
       );
 

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -29,6 +29,7 @@ void main() {
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],
+        <String>['lib/test/should_not_run_e2e.dart'],
         <String>['example', 'test', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
@@ -72,7 +73,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/test/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -92,7 +93,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/test/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -19,14 +19,14 @@ void main() {
 
     test('runs e2e tests', () async {
       createFakePlugin('plugin', withExtraFiles: [
-        <String>['example', 'test', 'plugin_e2e.dart']
-        <String>['example', 'test_driver', 'plugin_e2e_test.dart']
+        <String>['example', 'test', 'plugin_e2e.dart'],
+        <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
         <String>['example', 'android', 'gradlew'],
         <String>['example', 'android', 'app', 'src', 'androidTest', 'MainActivityTest.java'],
       ];
 
       List<String> plugins =
-      await runCapturingPrint(runner, <String>['firebase-test-lab']);
+          await runCapturingPrint(runner, <String>['firebase-test-lab']);
 
       expect(
         plugins,

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
@@ -54,7 +56,7 @@ void main() {
         orderedEquals(<ProcessCall>[
           ProcessCall(
               'gcloud',
-              'auth activate-service-account --key-file=/Users/jackson/gcloud-service-key.json'
+              'auth activate-service-account --key-file=${Platform.environment['HOME']}/gcloud-service-key.json'
                   .split(' '),
               null),
           ProcessCall('gcloud',

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -8,12 +8,14 @@ import 'util.dart';
 void main() {
   group('$FirebaseTestLabCommand', () {
     CommandRunner runner;
+    RecordingProcessRunner processRunner;
 
     setUp(() {
       initializeFakePackages();
+      processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir, mockFileSystem,
-          processRunner: RecordingProcessRunner());
+          processRunner: processRunner);
 
       runner = CommandRunner<Null>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
@@ -44,6 +46,17 @@ void main() {
           '\nRUNNING FIREBASE TEST LAB TESTS for plugin',
           '\n\n',
           'All Firebase Test Lab tests successful!',
+        ]),
+      );
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall('gcloud', 'auth activate-service-account --key-file=/Users/jackson/gcloud-service-key.json'.split(' '), null),
+          ProcessCall('gcloud', '--quiet config set project flutter-infra'.split(' '), null),
+          ProcessCall('/packages/plugin/example/android/gradlew app:assembleAndroidTest', '-Pverbose=true'.split(' '), '/packages/plugin/example/android'),
+          ProcessCall('/packages/plugin/example/android/gradlew', 'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'.split(' '), '/packages/plugin/example/android'),
+          ProcessCall('gcloud', 'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 2m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null'.split(' '), '/packages/plugin/example'),
         ]),
       );
 

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -1,0 +1,41 @@
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  group('$FirebaseTestLabCommand', () {
+    CommandRunner runner;
+
+    setUp(() {
+      initializeFakePackages();
+      final FirebaseTestLabCommand command = FirebaseTestLabCommand(mockPackagesDir, mockFileSystem, processRunner: mockProcessRunner);
+
+      runner = CommandRunner<Null>('firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
+      runner.addCommand(command);
+    });
+
+    test('runs e2e tests', () async {
+      createFakePlugin('plugin', withExtraFiles: [
+        <String>['example', 'test', 'plugin_e2e.dart']
+        <String>['example', 'test_driver', 'plugin_e2e_test.dart']
+        <String>['example', 'android', 'gradlew'],
+        <String>['example', 'android', 'app', 'src', 'androidTest', 'MainActivityTest.java'],
+      ];
+
+      List<String> plugins =
+      await runCapturingPrint(runner, <String>['firebase-test-lab']);
+
+      expect(
+        plugins,
+        orderedEquals(<String>[
+          'All Firebase Test Lab tests successful!'
+        ]),
+      );
+
+      cleanupPackages();
+    });
+  });
+}

--- a/test/util.dart
+++ b/test/util.dart
@@ -108,7 +108,7 @@ class RecordingProcessRunner extends ProcessRunner {
     Directory workingDir,
     bool exitOnError = false,
   }) {
-    recordedCalls.add(ProcessCall(executable, args, workingDir.path));
+    recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
     return Future<int>.value(0);
   }
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -118,7 +118,7 @@ class RecordingProcessRunner extends ProcessRunner {
     List<String> args, {
     Directory workingDir,
   }) {
-    recordedCalls.add(ProcessCall(executable, args, workingDir.path));
+    recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
     return Future<io.ProcessResult>.value(null);
   }
 }


### PR DESCRIPTION
Teaches flutter_plugin_tools to run the Firebase Test Lab tests using the new package convention. 

Added a test for the new behavior using the new `RecordingProcessRunner` that @hterkelsen added.