### PR TITLE
Fix version check command

### DIFF
--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -29,7 +29,7 @@ class GitVersionFinder {
 
   Future<List<String>> getChangedPubSpecs() async {
     final io.ProcessResult changedFilesCommand = await baseGitDir
-        .runCommand(<String>['diff', '--name-only', '$baseSha']);
+        .runCommand(<String>['diff', '--name-only', '$baseSha', 'HEAD']);
     final List<String> changedFiles =
         changedFilesCommand.stdout.toString().split('\n');
     return changedFiles.where(isPubspec).toList();
@@ -86,8 +86,9 @@ Map<Version, NextVersionType> getAllowedNextVersions(
 }
 
 class VersionCheckCommand extends PluginCommand {
-  VersionCheckCommand(Directory packagesDir, FileSystem fileSystem)
-      : super(packagesDir, fileSystem) {
+  VersionCheckCommand(Directory packagesDir, FileSystem fileSystem, {
+    ProcessRunner processRunner = const ProcessRunner(),
+  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(_kBaseSha);
   }
 

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -88,9 +88,15 @@ Map<Version, NextVersionType> getAllowedNextVersions(
 class VersionCheckCommand extends PluginCommand {
   VersionCheckCommand(Directory packagesDir, FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
+    this.gitDir,
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(_kBaseSha);
   }
+
+  /// The git directory to use. By default it uses the parent directory.
+  ///
+  /// This can be mocked for testing.
+  final GitDir gitDir;
 
   @override
   final String name = 'version-check';
@@ -107,12 +113,15 @@ class VersionCheckCommand extends PluginCommand {
     final String rootDir = packagesDir.parent.absolute.path;
     final String baseSha = argResults[_kBaseSha];
 
-    if (!await GitDir.isGitDir(rootDir)) {
-      print('$rootDir is not a valid Git repository.');
-      throw new ToolExit(2);
+    GitDir baseGitDir = gitDir;
+    if (baseGitDir == null) {
+      if (!await GitDir.isGitDir(rootDir)) {
+        print('$rootDir is not a valid Git repository.');
+        throw new ToolExit(2);
+      }
+      baseGitDir = await GitDir.fromExisting(rootDir);
     }
 
-    final GitDir baseGitDir = await GitDir.fromExisting(rootDir);
     final GitVersionFinder gitVersionFinder =
         GitVersionFinder(baseGitDir, baseSha);
 

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -86,7 +86,9 @@ Map<Version, NextVersionType> getAllowedNextVersions(
 }
 
 class VersionCheckCommand extends PluginCommand {
-  VersionCheckCommand(Directory packagesDir, FileSystem fileSystem, {
+  VersionCheckCommand(
+    Directory packagesDir,
+    FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
     this.gitDir,
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,5 +19,8 @@ dependencies:
   meta: ^1.1.7
   file: ^5.0.10
 
+dev_dependencies:
+  mockito: ^4.1.1
+
 environment:
   sdk: ">=1.8.0 <3.0.0"

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -32,7 +32,6 @@ class MockGitDir extends Mock implements GitDir {}
 class MockProcessResult extends Mock implements ProcessResult {}
 
 void main() {
-
   group('$VersionCheckCommand', () {
     CommandRunner runner;
     RecordingProcessRunner processRunner;
@@ -60,7 +59,8 @@ void main() {
 
     test('checks version', () async {
       createFakePlugin('plugin');
-      List<String> output = await runCapturingPrint(runner, <String>['version-check', '--base_sha=master']);
+      List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base_sha=master']);
 
       expect(
         output,
@@ -69,7 +69,8 @@ void main() {
         ]),
       );
       expect(gitDirCommands.length, equals(1));
-      expect(gitDirCommands.first.join(' '), equals('diff --name-only master HEAD'));
+      expect(gitDirCommands.first.join(' '),
+          equals('diff --name-only master HEAD'));
       cleanupPackages();
     });
   });

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -27,7 +27,6 @@ void testAllowedVersion(
   }
 }
 
-/// A mock [ProcessRunner] which records process calls.
 class MockGitDir extends Mock implements GitDir {}
 
 class MockProcessResult extends Mock implements ProcessResult {}

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -68,7 +68,7 @@ void main() {
           'No version check errors found!',
         ]),
       );
-      gitDirCommands.length == 0;
+      expect(gitDirCommands.length, equals(1));
       expect(gitDirCommands.first.join(' '), equals('diff --name-only master HEAD'));
       cleanupPackages();
     });


### PR DESCRIPTION
The version check command is supposed to compare two git refs, base and HEAD. However, in one place it looks at the working copy instead. This fixes the issue and adds a test for the correct behavior.

This change is required in order us to be able to temporarily remove web plugins when testing on stable without breaking the version check command (see flutter/plugins#2203)