### PR TITLE
Update DriveExamplesCommand to use ProcessRunner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.25
+
+- Still treat the tests as passed if all tests are skipped.
+
 ## v.0.0.24
 
 - Gracefully handle pubspec.yaml files for new plugins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v.0.0.25
 
-- Still treat the tests as passed if all tests are skipped.
+- Update `DriveExamplesCommand` to use `ProcessRunner`.
+- Make `DriveExamplesCommand` rely on `ProcessRunner` to determine if the test fails or not.
+- Add simple tests for `DriveExamplesCommand`.
 
 ## v.0.0.24
 

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -69,7 +69,7 @@ class DriveExamplesCommand extends PluginCommand {
 
         final int exitCode = await processRunner.runAndStream(
             'flutter', <String>['drive', deviceTestPath],
-            workingDir: example);
+            workingDir: example, exitOnError: true);
         if (exitCode != 0) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -77,7 +77,8 @@ class DriveExamplesCommand extends PluginCommand {
           if (data.contains('Some tests failed.')) {
             failingTests.add(p.join(packageName, deviceTestPath));
           }
-          if (data.contains('All tests passed!') || data.contains('All tests skipped.')) {
+          if (data.contains('All tests passed!') ||
+              data.contains('All tests skipped.')) {
             testsPassed = true;
           }
           io.stdout.write(data);

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -67,19 +67,10 @@ class DriveExamplesCommand extends PluginCommand {
           continue;
         }
 
-        bool testsPassed = false;
         final int exitCode = await processRunner.runAndStream(
             'flutter', <String>['drive', deviceTestPath],
-            workingDir: example, exitOnError: true);
-        final String data = io.stdout.toString();
-        if (data.contains('Some tests failed.')) {
-          failingTests.add(p.join(packageName, deviceTestPath));
-        }
-        if (data.contains('All tests passed!') ||
-            data.contains('All tests skipped!')) {
-          testsPassed = true;
-        }
-        if (exitCode != 0 || !testsPassed) {
+            workingDir: example);
+        if (exitCode != 0) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -68,7 +68,7 @@ class DriveExamplesCommand extends PluginCommand {
         }
 
         bool testsPassed = false;
-        await processRunner.runAndStream(
+        final int exitCode = await processRunner.runAndStream(
             'flutter', <String>['drive', deviceTestPath],
             workingDir: example, exitOnError: true);
         final String data = io.stdout.toString();
@@ -79,7 +79,7 @@ class DriveExamplesCommand extends PluginCommand {
             data.contains('All tests skipped!')) {
           testsPassed = true;
         }
-        if (!testsPassed) {
+        if (exitCode != 0 || !testsPassed) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -3,11 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
-
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
-
 import 'common.dart';
 
 class DriveExamplesCommand extends PluginCommand {

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -67,19 +67,17 @@ class DriveExamplesCommand extends PluginCommand {
           continue;
         }
 
-        bool testsPassed = false;
-        await processRunner.runAndStream(
+        bool testsPassed = true;
+        final int exitCode = await processRunner.runAndStream(
             'flutter', <String>['drive', deviceTestPath],
             workingDir: example, exitOnError: true);
         final String data = io.stdout.toString();
         if (data.contains('Some tests failed.')) {
           failingTests.add(p.join(packageName, deviceTestPath));
+          testsPassed = false;
         }
-        if (data.contains('All tests passed!') ||
-            data.contains('All tests skipped!')) {
-          testsPassed = true;
-        }
-        if (!testsPassed) {
+        
+        if (exitCode != 0 || !testsPassed) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -67,17 +67,19 @@ class DriveExamplesCommand extends PluginCommand {
           continue;
         }
 
-        bool testsPassed = true;
-        final int exitCode = await processRunner.runAndStream(
+        bool testsPassed = false;
+        await processRunner.runAndStream(
             'flutter', <String>['drive', deviceTestPath],
             workingDir: example, exitOnError: true);
         final String data = io.stdout.toString();
         if (data.contains('Some tests failed.')) {
           failingTests.add(p.join(packageName, deviceTestPath));
-          testsPassed = false;
         }
-        
-        if (exitCode != 0 || !testsPassed) {
+        if (data.contains('All tests passed!') ||
+            data.contains('All tests skipped!')) {
+          testsPassed = true;
+        }
+        if (!testsPassed) {
           failingTests.add(p.join(packageName, deviceTestPath));
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -77,7 +77,7 @@ class DriveExamplesCommand extends PluginCommand {
           if (data.contains('Some tests failed.')) {
             failingTests.add(p.join(packageName, deviceTestPath));
           }
-          if (data.contains('All tests passed!')) {
+          if (data.contains('All tests passed!') || data.contains('All tests skipped.')) {
             testsPassed = true;
           }
           io.stdout.write(data);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.24
+version: 0.0.25
 
 dependencies:
   args: "^1.4.3"

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -1,0 +1,93 @@
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  group('test drive_example_command', () {
+    CommandRunner<Null> runner;
+    RecordingProcessRunner processRunner;
+
+    setUp(() {
+      initializeFakePackages();
+      processRunner = RecordingProcessRunner();
+      final DriveExamplesCommand command = DriveExamplesCommand(
+          mockPackagesDir, mockFileSystem,
+          processRunner: processRunner);
+
+      runner = CommandRunner<Null>(
+          'drive_examples_command', 'Test for drive_example_command');
+      runner.addCommand(command);
+      cleanupPackages();
+    });
+
+    test('runs drive under folder "test"', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test', 'plugin.dart'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', <String>['drive', 'test/plugin.dart'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+
+    test('runs drive under folder "test_driver"', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', <String>['drive', 'test_driver/plugin.dart'],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
+  });
+}

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -66,7 +66,7 @@ void main() {
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
+      
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
       ]);

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -66,7 +66,7 @@ void main() {
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
-      
+
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
       ]);


### PR DESCRIPTION
This PR updated `DriveExamplesCommand` to use ProcessRunner to run the command and rely on `ProcessRunner` to determine if the test is successful.

It would also fix an issue that CI fails when all the tests are skipped.

failing CI example with skipped tests.

```
if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
flutter channel $CHANNEL
Switching to flutter channel 'master'...
git: Already on 'master'
git: Your branch is up to date with 'origin/master'.
./script/incremental_build.sh build-examples --ipa
Checking for changed packages from ffb7903e3570385c7ceb93266cb24c040b56e137
Detected changes in the following 1 package(s):
video_player
running build-examples --ipa
BUILDING IPA for video_player/example
Running "flutter pub get" in example...                            18.8s
Warning: Building for device with codesigning disabled. You will have to manually codesign before deploying to device.
Building io.flutter.videoPlayerExample for device (ios-release)...
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Running pod install...                                              4.6s
Running Xcode build...                                          
Xcode build done.                                           68.1s
Built /private/var/folders/sy/2x5qvs0n4lg18fry9jz4y21m0000gn/T/cirrus-ci-build/packages/video_player/example/build/ios/iphoneos/Runner.app.
All builds successful!
Running version check for changed packages
No version check errors found!
./script/incremental_build.sh drive-examples
Checking for changed packages from ffb7903e3570385c7ceb93266cb24c040b56e137
Detected changes in the following 1 package(s):
video_player
running drive-examples
RUNNING DRIVER TEST for video_player/example/test_driver/video_player.dart
Using device Flutter-iPhone.
Starting application: test_driver/video_player.dart
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Running pod install...                                              2.1s
Running Xcode build...                                          
Xcode build done.                                           35.4s
flutter: Observatory listening on http://127.0.0.1:50243/K-CB1-j6Gmc=/
[info ] FlutterDriver: Connecting to Flutter application at http://127.0.0.1:50243/K-CB1-j6Gmc=/
[trace] FlutterDriver: Isolate found with number: 349604513602507
[trace] FlutterDriver: Isolate is paused at start.
[trace] FlutterDriver: Attempting to resume isolate
[trace] FlutterDriver: Waiting for service extension
[info ] FlutterDriver: Connected to Flutter application.
        [x86_64] libnetcore-1229.250.15
    0   libnetwork.dylib                    0x0000000113c143b8 __nw_create_backtrace_string + 120
    1   libnetwork.dylib                    0x0000000113b6e4b9 nw_dictionary_set_value + 265
    2   libnetwork.dylib                    0x0000000113bbf436 nw_path_evaluator_cancel + 582
    3   MediaToolbox                        0x0000000120de7744 FigNWPathEvaluatorCreate + 886
    4   MediaToolbox                        0x0000000120e7da24 AttemptNetworkMonitorSetup + 214
    5   MediaToolbox                        0x0000000120e7d64f segPumpSendIndexFileRequest + 865
    6   MediaToolbox                        0x0000000120e97def segPumpRequestIndexForStream + 810
    7   MediaToolbox                        0x0000000120e94fb1 segPumpLoadInformation + 106
    8   MediaToolbox                        0x0000000120ed9619 EnsureBytePump + 478
    9   MediaToolbox                        0x0000000120ed0e5a PerformTransferBytePumpAsync + 46
 <…>
00:00 
+0
: Push a page contains video and pop back, do not crash.
Skip: This test works locally but fails on CI because the simulator is not able to access the local video assets.Un-skip this after iOS test is moved to firebase device lab on real devices
00:00 
+0
 ~1
: (tearDownAll)
00:00 
+0
 ~1
: All tests skipped.
Stopping application instance.
The following driver tests are failing (see above for details):
 * video_player/example/test_driver/video_player.dart
```