### PR TITLE
Add a publish_plugin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 ## v.0.0.26
 
 - Add a command for publishing plugins to pub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## v.0.0.26
+
+- Add a command for publishing plugins to pub.
+
 ## v.0.0.25
 
 - Update `DriveExamplesCommand` to use `ProcessRunner`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -122,7 +122,7 @@ linter:
     - super_goes_last
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # https://github.com/flutter/flutter/issues/5793
+    - unawaited_futures
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
     # - unnecessary_lambdas # https://github.com/dart-lang/linter/issues/498

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -264,8 +264,8 @@ class ProcessRunner {
   }) async {
     final io.Process process = await io.Process.start(executable, args,
         workingDirectory: workingDir?.path);
-    io.stdout.addStream(process.stdout);
-    io.stderr.addStream(process.stderr);
+    await io.stdout.addStream(process.stdout);
+    await io.stderr.addStream(process.stderr);
     if (exitOnError && await process.exitCode != 0) {
       final String error =
           _getErrorString(executable, args, workingDir: workingDir);
@@ -273,6 +273,19 @@ class ProcessRunner {
       throw new ToolExit(await process.exitCode);
     }
     return process.exitCode;
+  }
+
+  /// Starts the [executable] with [args].
+  ///
+  /// The current working directory of [executable] can be overridden by
+  /// passing [workingDir].
+  ///
+  /// Returns the started [io.Process].
+  Future<io.Process> start(String executable, List<String> args,
+      {Directory workingDirectory}) async {
+    final io.Process process = await io.Process.start(executable, args,
+        workingDirectory: workingDirectory?.path);
+    return process;
   }
 
   /// Run the [executable] with [args], throwing an error on non-zero exit code.

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -7,6 +7,7 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
+import 'package:flutter_plugin_tools/src/publish_plugin_command.dart';
 import 'package:path/path.dart' as p;
 
 import 'analyze_command.dart';
@@ -39,16 +40,17 @@ void main(List<String> args) {
   final CommandRunner<Null> commandRunner = new CommandRunner<Null>(
       'pub global run flutter_plugin_tools',
       'Productivity utils for hosting multiple plugins within one repository.')
-    ..addCommand(new TestCommand(packagesDir, fileSystem))
     ..addCommand(new AnalyzeCommand(packagesDir, fileSystem))
-    ..addCommand(new FormatCommand(packagesDir, fileSystem))
     ..addCommand(new BuildExamplesCommand(packagesDir, fileSystem))
+    ..addCommand(new CreateAllPluginsAppCommand(packagesDir, fileSystem))
     ..addCommand(new DriveExamplesCommand(packagesDir, fileSystem))
     ..addCommand(new FirebaseTestLabCommand(packagesDir, fileSystem))
+    ..addCommand(new FormatCommand(packagesDir, fileSystem))
     ..addCommand(new JavaTestCommand(packagesDir, fileSystem))
     ..addCommand(new ListCommand(packagesDir, fileSystem))
-    ..addCommand(new VersionCheckCommand(packagesDir, fileSystem))
-    ..addCommand(new CreateAllPluginsAppCommand(packagesDir, fileSystem));
+    ..addCommand(new PublishPluginCommand(packagesDir, fileSystem))
+    ..addCommand(new TestCommand(packagesDir, fileSystem))
+    ..addCommand(new VersionCheckCommand(packagesDir, fileSystem));
 
   commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e;

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -100,7 +100,7 @@ class PublishPluginCommand extends PluginCommand {
     }
     _print('Local repo is ready!');
 
-    await _publishOrDie();
+    await _publish();
     _print('Package published!');
     if (!argResults[_tagReleaseOption]) {
       return await _finishSuccesfully();
@@ -175,7 +175,7 @@ class PublishPluginCommand extends PluginCommand {
     return remoteInfo.stdout;
   }
 
-  Future<void> _publishOrDie() async {
+  Future<void> _publish() async {
     final List<String> publishFlags = argResults[_pubFlagsOption];
     _print(
         'Running `pub publish ${publishFlags.join(' ')}` in ${_packageDir.absolute.path}...\n');

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -40,7 +40,7 @@ class PublishPluginCommand extends PluginCommand {
     );
     argParser.addMultiOption(_pubFlagsOption,
         help:
-            'A list of options that will be forwarded on to pub. Seperate multiple flags with commas.');
+            'A list of options that will be forwarded on to pub. Separate multiple flags with commas.');
     argParser.addFlag(
       _tagReleaseOption,
       help: 'Whether or not to tag the release.',
@@ -78,7 +78,7 @@ class PublishPluginCommand extends PluginCommand {
 
   @override
   final String description =
-      'Attempts to publish the given plugin and tag its release on Github.';
+      'Attempts to publish the given plugin and tag its release on GitHub.';
 
   final Print _print;
   final Stdin _stdin;

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file/file.dart';
+import 'package:git/git.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'common.dart';
+
+/// Wraps pub publish with a few niceties used by the flutter/plugin team.
+///
+/// 1. Checks for any modified files in git and refuses to publish if there's an
+///    issue.
+/// 2. Tags the release with the format <package-name>v<package-version>.
+/// 3. Pushes the release to a remote.
+///
+/// Both 2 and 3 are optional, see `plugin_tools help publish-plugin` for full
+/// usage information.
+class PublishPluginCommand extends PluginCommand {
+  PublishPluginCommand(
+    Directory packagesDir,
+    FileSystem fileSystem, {
+    ProcessRunner processRunner = const ProcessRunner(),
+  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addOption(
+      _packageOption,
+      help: 'The package to publish.'
+          'If the package directory name is different than its pubspec.yaml name, then this should specify the directory.',
+    );
+    argParser.addMultiOption(_pubFlagsOption,
+        help:
+            'A list of options that will be forwarded on to pub. Seperate multiple flags with commas.');
+    argParser.addFlag(
+      _tagReleaseOption,
+      help: 'Whether or not to tag the release.',
+      defaultsTo: true,
+      negatable: true,
+    );
+    argParser.addFlag(
+      _pushTagsOption,
+      help:
+          'Whether or not tags should be pushed to a remote after creation. Ignored if tag-release is false.',
+      defaultsTo: true,
+      negatable: true,
+    );
+    argParser.addOption(
+      _remoteOption,
+      help:
+          'The name of the remote to push the tags to. Ignored if push-tags or tag-release is false.',
+      // Flutter convention is to use "upstream" for the single source of truth, and "origin" for personal forks.
+      defaultsTo: 'upstream',
+    );
+  }
+
+  static const String _packageOption = 'package';
+  static const String _tagReleaseOption = 'tag-release';
+  static const String _pushTagsOption = 'push-tags';
+  static const String _pubFlagsOption = 'pub-publish-flags';
+  static const String _remoteOption = 'remote';
+
+  // Version tags should follow <package-name>-v<semantic-version>. For example,
+  // `flutter_plugin_tools-v0.0.24`.
+  static const String _tagFormat = '%PACKAGE%-v%VERSION%';
+
+  @override
+  final String name = 'publish-plugin';
+
+  @override
+  final String description =
+      'Attempts to publish the given plugin and tag its release on Github.';
+
+  // The directory of the actual package that we are publishing.
+  Directory _packageDir;
+  StreamSubscription<String> _stdinSubscription;
+
+  @override
+  Future<Null> run() async {
+    checkSharding();
+    print('Checking local repo...');
+    _packageDir = _checkPackageDir();
+    await _checkGitStatus();
+    final bool shouldPushTag = argResults[_pushTagsOption];
+    final String remote = argResults[_remoteOption];
+    String remoteUrl;
+    if (shouldPushTag) {
+      remoteUrl = await _verifyRemote(remote);
+    }
+    print('Local repo is ready!');
+
+    await _publishOrDie();
+    print('Package published!');
+    if (!argResults[_tagReleaseOption]) {
+      await _finishSuccesfully();
+    }
+
+    print('Tagging release...');
+    final String tag = _getTag();
+    await processRunner.runAndExitOnError('git', <String>['tag', tag]);
+    if (!shouldPushTag) {
+      await _finishSuccesfully();
+    }
+
+    print('Pushing tag to $remote...');
+    await _pushTagToRemote(remote: remote, tag: tag, remoteUrl: remoteUrl);
+    await _finishSuccesfully();
+  }
+
+  Future<void> _finishSuccesfully() async {
+    await _stdinSubscription.cancel();
+    print('Done!');
+  }
+
+  Directory _checkPackageDir() {
+    final String package = argResults[_packageOption];
+    if (package == null) {
+      print(
+          'Must specify a package to publish. See `plugin_tools help publish-plugin`.');
+      throw ToolExit(1);
+    }
+    final Directory _packageDir = packagesDir.childDirectory(package);
+    if (!_packageDir.existsSync()) {
+      print('${_packageDir.absolute.path} does not exist.');
+      throw ToolExit(1);
+    }
+    if (!isFlutterPackage(_packageDir, fileSystem)) {
+      print('${_packageDir.absolute.path} is not a flutter package.');
+      throw ToolExit(1);
+    }
+    return _packageDir;
+  }
+
+  Future<void> _checkGitStatus() async {
+    if (!await GitDir.isGitDir(_packageDir.path)) {
+      print('$_packageDir is not a valid Git repository.');
+      throw ToolExit(1);
+    }
+
+    final ProcessResult statusResult = await processRunner.runAndExitOnError(
+        'git', <String>[
+      'status',
+      '--porcelain',
+      '--ignored',
+      _packageDir.absolute.path
+    ]);
+    final String statusOutput = statusResult.stdout;
+    if (statusOutput.isNotEmpty) {
+      print(
+          "There are files in the package directory that haven't been saved in git. Refusing to publish these files:\n\n"
+          '$statusOutput\n'
+          'If the directory should be clean, you can run `git clean -xdf && git reset --hard HEAD` to wipe all local changes.');
+      throw ToolExit(1);
+    }
+  }
+
+  Future<String> _verifyRemote(String remote) async {
+    final ProcessResult remoteInfo = await processRunner
+        .runAndExitOnError('git', <String>['remote', 'get-url', remote]);
+    return remoteInfo.stdout;
+  }
+
+  Future<void> _publishOrDie() async {
+    final List<String> publishFlags = argResults[_pubFlagsOption];
+    print(
+        'Running `pub publish ${publishFlags.join(' ')}` in ${_packageDir.absolute.path}...\n');
+    final Process publish = await processRunner.start(
+        'pub', <String>['publish'] + publishFlags,
+        workingDirectory: _packageDir.absolute);
+    publish.stdout.transform(utf8.decoder).listen((String data) => print(data));
+    publish.stderr.transform(utf8.decoder).listen((String data) => print(data));
+    _stdinSubscription = stdin
+        .transform(utf8.decoder)
+        .listen((String data) => publish.stdin.writeln(data));
+    final int result = await publish.exitCode;
+    if (result != 0) {
+      print('Publish failed. Exiting.');
+      throw ToolExit(result);
+    }
+  }
+
+  String _getTag() {
+    final File pubspecFile =
+        fileSystem.file(p.join(_packageDir.path, 'pubspec.yaml'));
+    final YamlMap pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
+    final String name = pubspecYaml['name'];
+    final String version = pubspecYaml['version'];
+    // We should have failed to publish if these were unset.
+    assert(name.isNotEmpty && version.isNotEmpty);
+    return _tagFormat
+        .replaceAll('%PACKAGE%', name)
+        .replaceAll('%VERSION%', version);
+  }
+
+  Future<void> _pushTagToRemote(
+      {@required String remote,
+      @required String tag,
+      @required String remoteUrl}) async {
+    assert(remote != null && tag != null && remoteUrl != null);
+    print('Ready to push $tag to $remoteUrl (y/n)?');
+    final String input = stdin.readLineSync();
+    if (input.toLowerCase() != 'y') {
+      print('Tag push canceled.');
+      throw ToolExit(1);
+    }
+
+    await processRunner.runAndExitOnError('git', <String>['push', remote, tag]);
+  }
+}

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -16,22 +16,22 @@ typedef void Print(Object object);
 ///
 /// 1. Checks for any modified files in git and refuses to publish if there's an
 ///    issue.
-/// 2. Tags the release with the format <package-name>v<package-version>.
+/// 2. Tags the release with the format <package-name>-v<package-version>.
 /// 3. Pushes the release to a remote.
 ///
 /// Both 2 and 3 are optional, see `plugin_tools help publish-plugin` for full
 /// usage information.
 ///
-/// [processRunner] and [print] can both be overriden for easier testing.
+/// [processRunner], [print], and [stdin] can be overriden for easier testing.
 class PublishPluginCommand extends PluginCommand {
   PublishPluginCommand(
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
     Print print = print,
-    Stdin stdin,
+    Stdin stdinput,
   })  : _print = print,
-        _stdin = stdin,
+        _stdin = stdinput ?? stdin,
         super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(
       _packageOption,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
 
 dev_dependencies:
   mockito: ^4.1.1
-  test_process: ^1.0.4
 
 environment:
   sdk: ">=1.8.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.25
+version: 0.0.26
 
 dependencies:
   args: "^1.4.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^4.1.1
+  test_process: ^1.0.4
 
 environment:
   sdk: ">=1.8.0 <3.0.0"

--- a/test/publish_plugin_command_test.dart
+++ b/test/publish_plugin_command_test.dart
@@ -1,0 +1,383 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:flutter_plugin_tools/src/publish_plugin_command.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
+import 'package:git/git.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  const String testPluginName = 'foo';
+  final List<String> printedMessages = <String>[];
+
+  Directory parentDir;
+  Directory pluginDir;
+  GitDir gitDir;
+  TestProcessRunner processRunner;
+  CommandRunner<Null> commandRunner;
+  MockStdin mockStdin;
+
+  setUp(() async {
+    // This test uses a local file system instead of an in memory one throughout
+    // so that git actually works. In setup we initialize a mono repo of plugins
+    // with one package and commit everything to Git.
+    parentDir = const LocalFileSystem()
+        .systemTempDirectory
+        .createTempSync('publish_plugin_command_test-');
+    initializeFakePackages(parentDir: parentDir);
+    pluginDir = createFakePlugin(testPluginName, withSingleExample: false);
+    assert(pluginDir != null && pluginDir.existsSync());
+    createFakePubspec(pluginDir);
+    io.Process.runSync('git', <String>['init'],
+        workingDirectory: mockPackagesDir.path);
+    gitDir = await GitDir.fromExisting(mockPackagesDir.path);
+    await gitDir.runCommand(<String>['add', '-A']);
+    await gitDir.runCommand(<String>['commit', '-m', 'Initial commit']);
+    processRunner = TestProcessRunner();
+    mockStdin = MockStdin();
+    // when(mockStdin.transform<dynamic>(argThat(anything)))
+    //     .thenAnswer((_) => const Stream<String>.empty());
+    commandRunner = CommandRunner<Null>('tester', '')
+      ..addCommand(PublishPluginCommand(
+          mockPackagesDir, const LocalFileSystem(),
+          processRunner: processRunner,
+          print: (Object message) => printedMessages.add(message.toString()),
+          stdin: mockStdin));
+  });
+
+  tearDown(() {
+    parentDir.deleteSync(recursive: true);
+    printedMessages.clear();
+  });
+
+  group('Initial validation', () {
+    test('requires a package flag', () async {
+      await expectLater(
+          () async => await commandRunner.run(<String>['publish-plugin']),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(
+          printedMessages.last, contains("Must specify a package to publish."));
+    });
+
+    test('requires an existing flag', () async {
+      await expectLater(
+          () async => await commandRunner
+              .run(<String>['publish-plugin', '--package', 'iamerror']),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(printedMessages.last, contains('iamerror does not exist'));
+    });
+
+    test('refuses to proceed with dirty files', () async {
+      pluginDir.childFile('tmp').createSync();
+
+      await expectLater(
+          () async => await commandRunner
+              .run(<String>['publish-plugin', '--package', testPluginName]),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(
+          printedMessages.last,
+          contains(
+              "There are files in the package directory that haven't been saved in git."));
+    });
+
+    test('fails immediately if the remote doesn\'t exist', () async {
+      await expectLater(
+          () async => await commandRunner
+              .run(<String>['publish-plugin', '--package', testPluginName]),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(processRunner.results.last.stderr, contains("No such remote"));
+    });
+
+    test("doesn't validate the remote if it's not pushing tags", () async {
+      // Immediately return 0 when running `pub publish`.
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+        '--no-tag-release'
+      ]);
+
+      expect(printedMessages.last, 'Done!');
+    });
+  });
+
+  group('Publishes package', () {
+    test('while showing all output from pub publish to the user', () async {
+      final Future<void> publishCommand = commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+        '--no-tag-release'
+      ]);
+      processRunner.mockPublishProcess.stdoutController.add(utf8.encode('Foo'));
+      processRunner.mockPublishProcess.stderrController.add(utf8.encode('Bar'));
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+
+      await publishCommand;
+
+      expect(printedMessages.contains('Foo'), isTrue);
+      expect(printedMessages.contains('Bar'), isTrue);
+    });
+
+    test('forwards input from the user to `pub publish`', () async {
+      final Future<void> publishCommand = commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+        '--no-tag-release'
+      ]);
+      mockStdin.controller.add(utf8.encode('user input'));
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+
+      await publishCommand;
+
+      expect(processRunner.mockPublishProcess.stdinMock.lines,
+          contains('user input'));
+    });
+
+    test('forwards --pub-publish-flags to pub publish', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+        '--no-tag-release',
+        '--pub-publish-flags',
+        '--dry-run,--server=foo'
+      ]);
+
+      expect(processRunner.mockPublishArgs.length, 3);
+      expect(processRunner.mockPublishArgs[0], 'publish');
+      expect(processRunner.mockPublishArgs[1], '--dry-run');
+      expect(processRunner.mockPublishArgs[2], '--server=foo');
+    });
+
+    test('throws if pub publish fails', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(128);
+      await expectLater(
+          () async => await commandRunner.run(<String>[
+                'publish-plugin',
+                '--package',
+                testPluginName,
+                '--no-push-tags',
+                '--no-tag-release',
+              ]),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(printedMessages, contains("Publish failed. Exiting."));
+    });
+  });
+
+  group('Tags release', () {
+    test('with the version and name from the pubspec.yaml', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+      ]);
+
+      final String tag =
+          (await gitDir.runCommand(<String>['show-ref', 'fake_package-v0.0.1']))
+              .stdout;
+      expect(tag, isNotEmpty);
+    });
+
+    test('only if publishing succeeded', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(128);
+      await expectLater(
+          () async => await commandRunner.run(<String>[
+                'publish-plugin',
+                '--package',
+                testPluginName,
+                '--no-push-tags',
+              ]),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(printedMessages, contains("Publish failed. Exiting."));
+      final String tag = (await gitDir.runCommand(
+              <String>['show-ref', 'fake_package-v0.0.1'],
+              throwOnError: false))
+          .stdout;
+      expect(tag, isEmpty);
+    });
+  });
+
+  group('Pushes tags', () {
+    setUp(() async {
+      await gitDir.runCommand(
+          <String>['remote', 'add', 'upstream', 'http://localhost:8000']);
+    });
+
+    test('requires user confirmation', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      mockStdin.readLineOutput = 'help';
+      await expectLater(
+          () async => await commandRunner.run(<String>[
+                'publish-plugin',
+                '--package',
+                testPluginName,
+              ]),
+          throwsA(const isInstanceOf<ToolExit>()));
+
+      expect(printedMessages, contains('Tag push canceled.'));
+    });
+
+    test('to upstream by default', () async {
+      await gitDir.runCommand(<String>['tag', 'garbage']);
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      mockStdin.readLineOutput = 'y';
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+      ]);
+
+      expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
+      expect(processRunner.pushTagsArgs[1], 'upstream');
+      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(printedMessages.last, 'Done!');
+    });
+
+    test('to different remotes based on a flag', () async {
+      await gitDir.runCommand(
+          <String>['remote', 'add', 'origin', 'http://localhost:8001']);
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      mockStdin.readLineOutput = 'y';
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--remote',
+        'origin',
+      ]);
+
+      expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
+      expect(processRunner.pushTagsArgs[1], 'origin');
+      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(printedMessages.last, 'Done!');
+    });
+
+    test('only if tagging and pushing to remotes are both enabled', () async {
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-tag-release',
+      ]);
+
+      expect(processRunner.pushTagsArgs.isEmpty, isTrue);
+      expect(printedMessages.last, 'Done!');
+    });
+  });
+}
+
+class TestProcessRunner extends ProcessRunner {
+  final List<io.ProcessResult> results = <io.ProcessResult>[];
+  final MockProcess mockPublishProcess = MockProcess();
+  final List<String> mockPublishArgs = <String>[];
+  final MockProcessResult mockPushTagsResult = MockProcessResult();
+  final List<String> pushTagsArgs = <String>[];
+
+  @override
+  Future<io.ProcessResult> runAndExitOnError(
+    String executable,
+    List<String> args, {
+    Directory workingDir,
+  }) async {
+    // Don't ever really push tags.
+    if (executable == 'git' && args.isNotEmpty && args[0] == 'push') {
+      pushTagsArgs.addAll(args);
+      return mockPushTagsResult;
+    }
+
+    final io.ProcessResult result = io.Process.runSync(executable, args,
+        workingDirectory: workingDir?.path);
+    results.add(result);
+    if (result.exitCode != 0) {
+      throw new ToolExit(result.exitCode);
+    }
+    return result;
+  }
+
+  @override
+  Future<io.Process> start(String executable, List<String> args,
+      {Directory workingDirectory}) async {
+    /// Never actually publish anything. Start is always and only used for this
+    /// since it returns something we can route stdin through.
+    assert(executable == 'pub' && args.isNotEmpty && args[0] == 'publish');
+    mockPublishArgs.addAll(args);
+    return mockPublishProcess;
+  }
+}
+
+class MockProcess extends Mock implements io.Process {
+  final Completer<int> exitCodeCompleter = Completer<int>();
+  final StreamController<List<int>> stdoutController =
+      StreamController<List<int>>();
+  final StreamController<List<int>> stderrController =
+      StreamController<List<int>>();
+  final MockIOSink stdinMock = MockIOSink();
+
+  @override
+  Future<int> get exitCode => exitCodeCompleter.future;
+
+  @override
+  Stream<List<int>> get stdout => stdoutController.stream;
+
+  @override
+  Stream<List<int>> get stderr => stderrController.stream;
+
+  @override
+  IOSink get stdin => stdinMock;
+}
+
+class MockIOSink extends Mock implements IOSink {
+  List<String> lines = <String>[];
+
+  @override
+  void writeln([Object obj = ""]) => lines.add(obj);
+}
+
+class MockStdin extends Mock implements io.Stdin {
+  final StreamController<List<int>> controller = StreamController<List<int>>();
+  String readLineOutput;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<dynamic, S> streamTransformer) {
+    return controller.stream.transform(streamTransformer);
+  }
+
+  @override
+  StreamSubscription<List<int>> listen(void onData(List<int> event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  @override
+  String readLineSync(
+          {Encoding encoding: io.systemEncoding, bool retainNewlines: false}) =>
+      readLineOutput;
+}
+
+class MockProcessResult extends Mock implements io.ProcessResult {}

--- a/test/publish_plugin_command_test.dart
+++ b/test/publish_plugin_command_test.dart
@@ -34,7 +34,7 @@ void main() {
     initializeFakePackages(parentDir: parentDir);
     pluginDir = createFakePlugin(testPluginName, withSingleExample: false);
     assert(pluginDir != null && pluginDir.existsSync());
-    createFakePubspec(pluginDir);
+    createFakePubspec(pluginDir, includeVersion: true);
     io.Process.runSync('git', <String>['init'],
         workingDirectory: mockPackagesDir.path);
     gitDir = await GitDir.fromExisting(mockPackagesDir.path);
@@ -42,14 +42,12 @@ void main() {
     await gitDir.runCommand(<String>['commit', '-m', 'Initial commit']);
     processRunner = TestProcessRunner();
     mockStdin = MockStdin();
-    // when(mockStdin.transform<dynamic>(argThat(anything)))
-    //     .thenAnswer((_) => const Stream<String>.empty());
     commandRunner = CommandRunner<Null>('tester', '')
       ..addCommand(PublishPluginCommand(
           mockPackagesDir, const LocalFileSystem(),
           processRunner: processRunner,
           print: (Object message) => printedMessages.add(message.toString()),
-          stdin: mockStdin));
+          stdinput: mockStdin));
   });
 
   tearDown(() {
@@ -130,8 +128,8 @@ void main() {
 
       await publishCommand;
 
-      expect(printedMessages.contains('Foo'), isTrue);
-      expect(printedMessages.contains('Bar'), isTrue);
+      expect(printedMessages, contains('Foo'));
+      expect(printedMessages, contains('Bar'));
     });
 
     test('forwards input from the user to `pub publish`', () async {

--- a/test/publish_plugin_command_test.dart
+++ b/test/publish_plugin_command_test.dart
@@ -57,8 +57,7 @@ void main() {
 
   group('Initial validation', () {
     test('requires a package flag', () async {
-      await expectLater(
-          () async => await commandRunner.run(<String>['publish-plugin']),
+      await expectLater(() => commandRunner.run(<String>['publish-plugin']),
           throwsA(const isInstanceOf<ToolExit>()));
 
       expect(
@@ -67,7 +66,7 @@ void main() {
 
     test('requires an existing flag', () async {
       await expectLater(
-          () async => await commandRunner
+          () => commandRunner
               .run(<String>['publish-plugin', '--package', 'iamerror']),
           throwsA(const isInstanceOf<ToolExit>()));
 
@@ -78,7 +77,7 @@ void main() {
       pluginDir.childFile('tmp').createSync();
 
       await expectLater(
-          () async => await commandRunner
+          () => commandRunner
               .run(<String>['publish-plugin', '--package', testPluginName]),
           throwsA(const isInstanceOf<ToolExit>()));
 
@@ -90,7 +89,7 @@ void main() {
 
     test('fails immediately if the remote doesn\'t exist', () async {
       await expectLater(
-          () async => await commandRunner
+          () => commandRunner
               .run(<String>['publish-plugin', '--package', testPluginName]),
           throwsA(const isInstanceOf<ToolExit>()));
 
@@ -170,7 +169,7 @@ void main() {
     test('throws if pub publish fails', () async {
       processRunner.mockPublishProcess.exitCodeCompleter.complete(128);
       await expectLater(
-          () async => await commandRunner.run(<String>[
+          () => commandRunner.run(<String>[
                 'publish-plugin',
                 '--package',
                 testPluginName,
@@ -202,7 +201,7 @@ void main() {
     test('only if publishing succeeded', () async {
       processRunner.mockPublishProcess.exitCodeCompleter.complete(128);
       await expectLater(
-          () async => await commandRunner.run(<String>[
+          () => commandRunner.run(<String>[
                 'publish-plugin',
                 '--package',
                 testPluginName,
@@ -229,7 +228,7 @@ void main() {
       processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
       mockStdin.readLineOutput = 'help';
       await expectLater(
-          () async => await commandRunner.run(<String>[
+          () => commandRunner.run(<String>[
                 'publish-plugin',
                 '--package',
                 testPluginName,

--- a/test/util.dart
+++ b/test/util.dart
@@ -76,7 +76,7 @@ dependencies:
   if (includeVersion) {
     yaml += '''
 version: 0.0.1
-publish_to: none
+publish_to: none # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);

--- a/test/util.dart
+++ b/test/util.dart
@@ -15,7 +15,8 @@ Directory mockPackagesDir;
 /// If [parentDir] is set the mock packages dir will be creates as a child of
 /// it. If not [mockFileSystem] will be used instead.
 void initializeFakePackages({Directory parentDir}) {
-  mockPackagesDir = (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
+  mockPackagesDir =
+      (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
   mockPackagesDir.createSync();
 }
 
@@ -59,24 +60,26 @@ Directory createFakePlugin(
 }
 
 /// Creates a `pubspec.yaml` file with a flutter dependency.
-void createFakePubspec(Directory parent, {bool isFlutter = true}) {
+void createFakePubspec(Directory parent,
+    {bool isFlutter = true, bool includeVersion = false}) {
   parent.childFile('pubspec.yaml').createSync();
-  if (isFlutter) {
-    parent.childFile('pubspec.yaml').writeAsStringSync('''
+  String yaml = '''
 name: fake_package
+''';
+  if (isFlutter) {
+    yaml += '''
 dependencies:
   flutter:
     sdk: flutter
-version: 0.0.1
-publish_to: none
-''');
-  } else {
-    parent.childFile('pubspec.yaml').writeAsStringSync('''
-name: fake_package
-version: 0.0.1
-publish_to: none
-''');
+''';
   }
+  if (includeVersion) {
+    yaml += '''
+version: 0.0.1
+publish_to: none
+''';
+  }
+  parent.childFile('pubspec.yaml').writeAsStringSync(yaml);
 }
 
 /// Cleans up the mock packages directory, making it an empty directory again.

--- a/test/util.dart
+++ b/test/util.dart
@@ -11,13 +11,15 @@ final FileSystem mockFileSystem = MemoryFileSystem();
 Directory mockPackagesDir;
 
 /// Creates a mock packages directory in the mock file system.
-void initializeFakePackages() {
-  mockPackagesDir = mockFileSystem.currentDirectory.childDirectory('packages');
+///
+/// If [parentDir] is set the mock packages dir will be creates as a child of
+/// it. If not [mockFileSystem] will be used instead.
+void initializeFakePackages({Directory parentDir}) {
+  mockPackagesDir = (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
   mockPackagesDir.createSync();
 }
 
-/// Creates a plugin package with the given [name] under the mock packages
-/// directory.
+/// Creates a plugin package with the given [name] in [mockPackagesDir].
 Directory createFakePlugin(
   String name, {
   bool withSingleExample: false,
@@ -65,10 +67,14 @@ name: fake_package
 dependencies:
   flutter:
     sdk: flutter
+version: 0.0.1
+publish_to: none
 ''');
   } else {
     parent.childFile('pubspec.yaml').writeAsStringSync('''
 name: fake_package
+version: 0.0.1
+publish_to: none
 ''');
   }
 }


### PR DESCRIPTION
This wraps `pub publish` with a few niceties for the flutter team.

1. Checks for any modified files in git and refuses to publish if there's an
   issue.
2. Tags the release with the format <package-name>v<package-version>.
3. Pushes the release to a remote.

Fixes flutter/flutter#42934.
Helps some points in flutter/flutter#27258.