### PR TITLE
Increase Firebase device lab timeout to 5 minutes

### DIFF
--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -180,7 +180,7 @@ class FirebaseTestLabCommand extends PluginCommand {
             '--test',
             'build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
             '--timeout',
-            '2m',
+            '5m',
             '--results-bucket=${argResults['results-bucket']}',
             '--results-dir=${argResults['results-dir']}',
           ];

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -180,7 +180,7 @@ class FirebaseTestLabCommand extends PluginCommand {
             '--test',
             'build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
             '--timeout',
-            '15m',
+            '5m',
             '--results-bucket=${argResults['results-bucket']}',
             '--results-dir=${argResults['results-dir']}',
           ];

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -180,7 +180,7 @@ class FirebaseTestLabCommand extends PluginCommand {
             '--test',
             'build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
             '--timeout',
-            '5m',
+            '15m',
             '--results-bucket=${argResults['results-bucket']}',
             '--results-dir=${argResults['results-dir']}',
           ];


### PR DESCRIPTION
In order to allow for testing of the android_alarm_manager plugin we need to increase the timeout for Firebase tests. The E2E test for the alarm manager seems to take ~2.5 minutes on average but the API cannot guarantee when alarms are fired. 5 minutes seems to be sufficient given my observations.