### PR TITLE
Add support for macos build and drive examples scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.31
+
+- Add support for macos on `DriveExamplesCommand` and `BuildExamplesCommand`.
+
 ## v.0.0.30
 
 - Adopt pedantic analysis options, fix firebase_test_lab_test.

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -45,6 +45,12 @@ class BuildExamplesCommand extends PluginCommand {
 
       if (argResults['macos']) {
         print('\nBUILDING macos for $packageName');
+        final Directory macosDir =
+            fileSystem.directory(p.join(example.path, 'macos'));
+        if (!macosDir.existsSync()) {
+          print('No macOS implementation found.');
+          continue;
+        }
         final int exitCode = await processRunner.runAndStream(
             'flutter', <String>['build', 'macos'],
             workingDir: example);

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -12,7 +12,9 @@ class DriveExamplesCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner);
+  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addFlag('macos', help: 'Runs the macOS implementation of the examples');
+  }
 
   @override
   final String name = 'drive-examples';
@@ -28,9 +30,18 @@ class DriveExamplesCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingTests = <String>[];
+    final bool isMacos = argResults['macos'];
     await for (Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
+      // If macos is specified, filter out plugins that don't have a macos implementation yet.
+      if (isMacos) {
+        final Directory macosDir =
+            fileSystem.directory(p.join(example.path, 'macos'));
+        if (!macosDir.existsSync()) {
+          continue;
+        }
+      }
       final Directory driverTests =
           fileSystem.directory(p.join(example.path, 'test_driver'));
       if (!driverTests.existsSync()) {
@@ -64,8 +75,16 @@ class DriveExamplesCommand extends PluginCommand {
           continue;
         }
 
+      final List<String> driveArgs = <String>['drive'];
+        if (isMacos) {
+          driveArgs.addAll(<String>[
+            '-d',
+            'macos',
+          ]);
+        }
+        driveArgs.add(deviceTestPath);
         final int exitCode = await processRunner.runAndStream(
-            'flutter', <String>['drive', deviceTestPath],
+            'flutter', driveArgs,
             workingDir: example, exitOnError: true);
         if (exitCode != 0) {
           failingTests.add(p.join(packageName, deviceTestPath));

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -13,7 +13,8 @@ class DriveExamplesCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
-    argParser.addFlag('macos', help: 'Runs the macOS implementation of the examples');
+    argParser.addFlag('macos',
+        help: 'Runs the macOS implementation of the examples');
   }
 
   @override
@@ -75,7 +76,7 @@ class DriveExamplesCommand extends PluginCommand {
           continue;
         }
 
-      final List<String> driveArgs = <String>['drive'];
+        final List<String> driveArgs = <String>['drive'];
         if (isMacos) {
           driveArgs.addAll(<String>[
             '-d',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.30
+version: 0.0.31
 
 dependencies:
   args: "^1.4.3"

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -65,7 +65,7 @@ void main() {
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa']);
+          runner, <String>['build-examples', '--no-ipa', '--macos']);
 
       expect(
         output,

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -1,0 +1,120 @@
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/build_examples_command.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  group('test build_example_command', () {
+    CommandRunner<Null> runner;
+    RecordingProcessRunner processRunner;
+
+    setUp(() {
+      initializeFakePackages();
+      processRunner = RecordingProcessRunner();
+      final BuildExamplesCommand command = BuildExamplesCommand(
+          mockPackagesDir, mockFileSystem,
+          processRunner: processRunner);
+
+      runner = CommandRunner<Null>(
+          'build_examples_command', 'Test for build_example_command');
+      runner.addCommand(command);
+      cleanupPackages();
+    });
+
+    test('runs build under for ios', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-macos']);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING IPA for plugin/example',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', <String>['build', 'ios', '--no-codesign'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+    test('runs build under for macos', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-ipa']);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING macos for plugin/example',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', <String>['build', 'macos'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+    test('runs build under for android', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner,
+          <String>['build-examples', '--apk', '--no-ipa', '--no-macos']);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING APK for plugin/example',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', <String>['build', 'apk'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+  });
+}

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -23,7 +23,7 @@ void main() {
       cleanupPackages();
     });
 
-    test('runs build under for ios', () async {
+    test('runs build for ios', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);
@@ -34,7 +34,7 @@ void main() {
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-macos']);
+          runner, <String>['build-examples', '--ipa', '--no-macos']);
 
       expect(
         output,
@@ -54,7 +54,7 @@ void main() {
           ]));
       cleanupPackages();
     });
-    test('runs build under for macos', () async {
+    test('runs build for macos', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);
@@ -85,7 +85,7 @@ void main() {
           ]));
       cleanupPackages();
     });
-    test('runs build under for android', () async {
+    test('runs build for android', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -54,9 +54,41 @@ void main() {
           ]));
       cleanupPackages();
     });
+    test('runs build for macos with no implementation results in no-op', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-ipa', '--macos']);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING macos for plugin/example',
+          '\No macOS implementation found.',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // Output should be empty since running build-examples --macos with no macos
+      // implementation is a no-op.
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[]));
+      cleanupPackages();
+    });
     test('runs build for macos', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
+        <String>['example', 'macos', 'macos.swift'],
       ]);
 
       final Directory pluginExampleDirectory =
@@ -85,6 +117,7 @@ void main() {
           ]));
       cleanupPackages();
     });
+
     test('runs build for android', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -54,7 +54,8 @@ void main() {
           ]));
       cleanupPackages();
     });
-    test('runs build for macos with no implementation results in no-op', () async {
+    test('runs build for macos with no implementation results in no-op',
+        () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);
@@ -80,9 +81,7 @@ void main() {
       print(processRunner.recordedCalls);
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
-      expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[]));
+      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
       cleanupPackages();
     });
     test('runs build for macos', () async {

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -89,5 +89,73 @@ void main() {
 
       cleanupPackages();
     });
+    test('runs drive with no macos implementation', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--macos',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // Output should be empty since running drive-examples --macos with no macos
+      // implementation is a no-op.
+      expect(processRunner.recordedCalls, <ProcessCall>[]);
+
+      cleanupPackages();
+    });
+    test('runs drive with a macOS implementation', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+        <String>['example', 'macos', 'macos.swift'],
+      ]);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--macos',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                'flutter',
+                <String>['drive', '-d', 'macos', 'test_driver/plugin.dart'],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
   });
 }


### PR DESCRIPTION
For build_examples_command.dart, add --macos (added by default on macos hosts) to build the macos version of the example. If there is no macos implementation, the command fails but the script continues onto the next plugin.

For drive_examples_command.dart, add --macos to run `flutter drive -d macos` to make sure the macos implementation is run even if there are devices attached to the host.