### PR TITLE
Add CHANGELOG and bump version for podspec lint command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.29
+
+- Add a command to run pod lib lint on podspec files.
+
 ## v.0.0.28
 
 - Increase Firebase test lab timeouts to 5 minutes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.28
+version: 0.0.29
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Forgot to bump the version for https://github.com/flutter/plugin_tools/pull/69.