### PR TITLE
Fix publish warning, pin analysis_options to version

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   file: ^5.0.10
 
 dev_dependencies:
+  matcher: ^0.12.6
   mockito: ^4.1.1
   pedantic: ^1.8.0
 


### PR DESCRIPTION
Add matcher to pubspec dependencies.
```
Suggestions:
* line 11, column 1 of test/publish_plugin_command_test.dart: This package does not have matcher in the `dependencies` section of `pubspec.yaml`.
     ╷
  11 │ import 'package:matcher/matcher.dart';
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
```
Peg analysis_options to a version.  It already failed when I `pub get`'d up to 1.8.0+1.