### PR TITLE
Add --skip and --no-analyze flags to podspec command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.31+1
+
+- Add --skip and --no-analyze flags to podspec command.
+
 ## v.0.0.31
 
 - Add support for macos on `DriveExamplesCommand` and `BuildExamplesCommand`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.31
+version: 0.0.31+1
 
 dependencies:
   args: "^1.4.3"

--- a/test/lint_podspecs_command_test.dart
+++ b/test/lint_podspecs_command_test.dart
@@ -93,11 +93,15 @@ void main() {
     });
 
     test('skips podspecs with known warnings', () async {
-      createFakePlugin('url_launcher_web', withExtraFiles: <List<String>>[
-        <String>['url_launcher_web.podspec']
+      createFakePlugin('plugin1', withExtraFiles: <List<String>>[
+        <String>['plugin1.podspec']
+      ]);
+      createFakePlugin('plugin2', withExtraFiles: <List<String>>[
+        <String>['plugin2.podspec']
       ]);
 
-      await runner.run(<String>['podspecs']);
+      await runner
+          .run(<String>['podspecs', '--skip=plugin1', '--skip=plugin2']);
 
       expect(
         processRunner.recordedCalls,
@@ -111,11 +115,11 @@ void main() {
 
     test('skips analyzer for podspecs with known warnings', () async {
       Directory plugin1Dir =
-          createFakePlugin('camera', withExtraFiles: <List<String>>[
-        <String>['camera.podspec'],
+          createFakePlugin('plugin1', withExtraFiles: <List<String>>[
+        <String>['plugin1.podspec'],
       ]);
 
-      await runner.run(<String>['podspecs']);
+      await runner.run(<String>['podspecs', '--no-analyze=plugin1']);
 
       expect(
         processRunner.recordedCalls,
@@ -126,7 +130,7 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'camera.podspec'),
+                p.join(plugin1Dir.path, 'plugin1.podspec'),
                 '--allow-warnings',
                 '--fail-fast',
                 '--silent',
@@ -138,7 +142,7 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'camera.podspec'),
+                p.join(plugin1Dir.path, 'plugin1.podspec'),
                 '--allow-warnings',
                 '--fail-fast',
                 '--silent',


### PR DESCRIPTION
Add flag to pass in which podspecs are to be skipped so this package isn't specific to `flutter/plugins` and doesn't need to be updated when new podspecs need to be skipped.