### PR TITLE
Fail extra analysis_options by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v.0.0.32
+
+- `analyze` now asserts that the global `analysis_options.yaml` is the only one
+  by default. Individual directories can be excluded from this check with the
+  new `--custom-analysis` flag.
+
 ## v.0.0.31+1
 
 - Add --skip and --no-analyze flags to podspec command.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.31+1
+version: 0.0.32
 
 dependencies:
   args: "^1.4.3"

--- a/test/analyze_command_test.dart
+++ b/test/analyze_command_test.dart
@@ -1,0 +1,95 @@
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/analyze_command.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+import 'util.dart';
+
+void main() {
+  RecordingProcessRunner processRunner;
+  CommandRunner runner;
+
+  setUp(() {
+    initializeFakePackages();
+    processRunner = RecordingProcessRunner();
+    final AnalyzeCommand analyzeCommand = AnalyzeCommand(
+        mockPackagesDir, mockFileSystem,
+        processRunner: processRunner);
+
+    runner = CommandRunner<Null>(
+        'drive_examples_command', 'Test for drive_example_command');
+    runner.addCommand(analyzeCommand);
+  });
+
+  tearDown(() {
+    mockPackagesDir.deleteSync(recursive: true);
+  });
+
+
+  test('analyzes all packages', () async {
+    final Directory plugin1Dir = await createFakePlugin('a');
+    final Directory plugin2Dir = await createFakePlugin('b');
+
+    final MockProcess mockProcess = MockProcess();
+    mockProcess.exitCodeCompleter.complete(0);
+    processRunner.processToReturn = mockProcess;
+    await runner.run(<String>['analyze']);
+
+    expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall('pub', <String>['global', 'activate', 'tuneup'],
+              mockPackagesDir.path),
+          ProcessCall('flutter', <String>['packages', 'get'], plugin1Dir.path),
+          ProcessCall('flutter', <String>['packages', 'get'], plugin2Dir.path),
+          ProcessCall('pub', <String>['global', 'run', 'tuneup', 'check'],
+              plugin1Dir.path),
+          ProcessCall('pub', <String>['global', 'run', 'tuneup', 'check'],
+              plugin2Dir.path),
+        ]));
+  });
+
+  group('verifies analysis settings', () {
+    test('fails analysis_options.yaml', () async {
+      await createFakePlugin('foo', withExtraFiles: <List<String>>[
+        <String>['analysis_options.yaml']
+      ]);
+
+      await expectLater(() => runner.run(<String>['analyze']),
+          throwsA(const TypeMatcher<ToolExit>()));
+    });
+
+    test('fails .analysis_options', () async {
+      await createFakePlugin('foo', withExtraFiles: <List<String>>[
+        <String>['.analysis_options']
+      ]);
+
+      await expectLater(() => runner.run(<String>['analyze']),
+          throwsA(const TypeMatcher<ToolExit>()));
+    });
+
+    test('takes a whitelist', () async {
+      final Directory pluginDir =
+          await createFakePlugin('foo', withExtraFiles: <List<String>>[
+        <String>['analysis_options.yaml']
+      ]);
+
+      final MockProcess mockProcess = MockProcess();
+      mockProcess.exitCodeCompleter.complete(0);
+      processRunner.processToReturn = mockProcess;
+      await runner.run(<String>['analyze', '--custom-analysis', 'foo']);
+
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('pub', <String>['global', 'activate', 'tuneup'],
+                mockPackagesDir.path),
+            ProcessCall('flutter', <String>['packages', 'get'], pluginDir.path),
+            ProcessCall('pub', <String>['global', 'run', 'tuneup', 'check'],
+                pluginDir.path),
+          ]));
+    });
+  });
+}

--- a/test/analyze_command_test.dart
+++ b/test/analyze_command_test.dart
@@ -27,7 +27,6 @@ void main() {
     mockPackagesDir.deleteSync(recursive: true);
   });
 
-
   test('analyzes all packages', () async {
     final Directory plugin1Dir = await createFakePlugin('a');
     final Directory plugin2Dir = await createFakePlugin('b');


### PR DESCRIPTION
Prevents packages from accidentally excluding themselves from the global
linter settings. Can be turned off for specific packages with a
whitelist flag.

DO NOT MERGE until there is a matching PR ready to land in flutter/plugins that passes a `--custom-analysis` with all the currently special cased plugins to CI.