### PR TITLE
Lock pedantic package to a version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 dev_dependencies:
   matcher: ^0.12.6
   mockito: ^4.1.1
-  pedantic: ^1.8.0
+  pedantic: 1.8.0
 
 environment:
   sdk: ">=2.3.0 <3.0.0"


### PR DESCRIPTION
Lock pedantic version to 1.8.0 to avoid the CI from upgrading and introducing new linter rules.

I did only half of this by locking the analysis_options.yaml. https://github.com/flutter/plugin_tools/blob/master/analysis_options.yaml#L1