### PR TITLE
Update deprecated test device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.32+3
+
+- Update Firebase Testlab deprecated test device. (Pixel 3 API 28 -> Pixel 4 API 29).
+
 ## v.0.0.32+2
 
 - Runs pub get before building macos to avoid failures.

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -28,7 +28,7 @@ class FirebaseTestLabCommand extends PluginCommand {
         splitCommas: false,
         defaultsTo: <String>[
           'model=walleye,version=26',
-          'model=blueline,version=28'
+          'model=flame,version=29'
         ],
         help:
             'Device model(s) to test. See https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run for more info');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+2
+version: 0.0.32+3
 
 dependencies:
   args: "^1.4.3"

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -47,7 +47,7 @@ void main() {
       final List<String> output = await runCapturingPrint(runner, <String>[
         'firebase-test-lab',
         '--device',
-        'model=blueline,version=28',
+        'model=flame,version=29',
         '--device',
         'model=seoul,version=26',
       ]);
@@ -82,7 +82,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=blueline,version=28 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -92,7 +92,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=blueline,version=28 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -102,7 +102,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=blueline,version=28 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),


### PR DESCRIPTION
This updates the [Pixel 3 API 28](https://firebase.corp.google.com/project/flutter-infra/testlab/histories/bh.35fea5f031537519/matrices/5188602872602900626/executions/bs.3e712794ab20ada2), which is now deprecated, to the Pixel 4 API 29. You can see the full list of devices using the [Google APIs Explorer](https://developers.google.com/apis-explorer/?authuser=0#p/testing/v1/testing.testEnvironmentCatalog.get?environmentType=ANDROID). 

According to [firebase api](https://firebase.google.com/docs/test-lab/android/available-testing-devices?authuser=0#deprecated):

> Deprecated devices are available for up to one month before being removed from the Test Lab Device Selection Catalog. If you try to run a test on a device after it’s been removed from the catalog, Test Lab will skip that test or throw an error and cancel all your tests.