### PR TITLE
Update `publish-plugin` to use `flutter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v.0.0.32+4
+
+- Update `publish-plugin` to use `flutter pub publish` instead of just `pub
+  publish`. Enforces a `pub publish` command that matches the Dart SDK in the
+  user's Flutter install.
+
 ## v.0.0.32+3
 
 - Update Firebase Testlab deprecated test device. (Pixel 3 API 28 -> Pixel 4 API 29).

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -180,7 +180,7 @@ class PublishPluginCommand extends PluginCommand {
     _print(
         'Running `pub publish ${publishFlags.join(' ')}` in ${_packageDir.absolute.path}...\n');
     final Process publish = await processRunner.start(
-        'pub', <String>['publish'] + publishFlags,
+        'flutter', <String>['pub', 'publish'] + publishFlags,
         workingDirectory: _packageDir);
     publish.stdout
         .transform(utf8.decoder)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+3
+version: 0.0.32+4
 
 dependencies:
   args: "^1.4.3"

--- a/test/publish_plugin_command_test.dart
+++ b/test/publish_plugin_command_test.dart
@@ -162,10 +162,11 @@ void main() {
         '--dry-run,--server=foo'
       ]);
 
-      expect(processRunner.mockPublishArgs.length, 3);
-      expect(processRunner.mockPublishArgs[0], 'publish');
-      expect(processRunner.mockPublishArgs[1], '--dry-run');
-      expect(processRunner.mockPublishArgs[2], '--server=foo');
+      expect(processRunner.mockPublishArgs.length, 4);
+      expect(processRunner.mockPublishArgs[0], 'pub');
+      expect(processRunner.mockPublishArgs[1], 'publish');
+      expect(processRunner.mockPublishArgs[2], '--dry-run');
+      expect(processRunner.mockPublishArgs[3], '--server=foo');
     });
 
     test('throws if pub publish fails', () async {
@@ -323,7 +324,10 @@ class TestProcessRunner extends ProcessRunner {
       {Directory workingDirectory}) async {
     /// Never actually publish anything. Start is always and only used for this
     /// since it returns something we can route stdin through.
-    assert(executable == 'pub' && args.isNotEmpty && args[0] == 'publish');
+    assert(executable == 'flutter' &&
+        args.isNotEmpty &&
+        args[0] == 'pub' &&
+        args[1] == 'publish');
     mockPublishArgs.addAll(args);
     return mockPublishProcess;
   }


### PR DESCRIPTION
Previously it was just using `pub publish`. Switching to `flutter pub
publish` instead ensures that the Dart SDK in the user's Flutter install is
being used for the command.