### PR TITLE
Update Firebase Test Lab command to ensure a unique results directory for each plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.32+6
+
+- Ensure that Firebase Test Lab tests have a unique storage bucket for each package.
+
 ## v.0.0.32+5
 
 - Remove --fail-fast and --silent from lint podspec command.

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -34,10 +34,6 @@ class FirebaseTestLabCommand extends PluginCommand {
             'Device model(s) to test. See https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run for more info');
     argParser.addOption('results-bucket',
         defaultsTo: 'gs://flutter_firebase_testlab');
-    final String gitRevision = io.Platform.environment['GIT_REVISION'];
-    final String buildId = io.Platform.environment['CIRRUS_BUILD_ID'];
-    argParser.addOption('results-dir',
-        defaultsTo: 'plugins_android_test/$gitRevision/$buildId');
   }
 
   @override
@@ -168,6 +164,8 @@ class FirebaseTestLabCommand extends PluginCommand {
             failingPackages.add(packageName);
             continue;
           }
+          final String buildId = io.Platform.environment['CIRRUS_BUILD_ID'];
+          final String resultsDir = 'plugins_android_test/$packageName/$buildId';
           final List<String> args = <String>[
             'firebase',
             'test',
@@ -182,7 +180,7 @@ class FirebaseTestLabCommand extends PluginCommand {
             '--timeout',
             '5m',
             '--results-bucket=${argResults['results-bucket']}',
-            '--results-dir=${argResults['results-dir']}',
+            '--results-dir=${resultsDir}',
           ];
           for (String device in argResults['device']) {
             args.addAll(<String>['--device', device]);

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -165,7 +165,8 @@ class FirebaseTestLabCommand extends PluginCommand {
             continue;
           }
           final String buildId = io.Platform.environment['CIRRUS_BUILD_ID'];
-          final String resultsDir = 'plugins_android_test/$packageName/$buildId';
+          final String resultsDir =
+              'plugins_android_test/$packageName/$buildId';
           final List<String> args = <String>[
             'firebase',
             'test',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+5
+version: 0.0.32+6
 
 dependencies:
   args: "^1.4.3"

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -82,7 +82,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -92,7 +92,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -102,7 +102,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/null/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),


### PR DESCRIPTION
From a report from @amirh:

> Looking at the log here: https://cirrus-ci.com/task/6532224191299584
> It seems like this should be the link for the webview test run results:  https://console.developers.google.com/storage/browser/flutter_firebase_testlab/plugins_android_test/null/6677294899003392/
> 
> But from the attached video it actually seems like local_auth has been running...
> 

A possible explanation is that we're sharing a bucket across all the Firebase Test Lab tests. There's no valid reason to do this, so I'd like to make the buckets unique in the hopes that it will fix the webview testing issue.

## Related Issues

This change might also fix these long standing team issues:

https://github.com/flutter/flutter/issues/46656
https://github.com/flutter/flutter/issues/46132