### PR TITLE
Further improvements to prevent results directory sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.32+7
+
+- Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.
+
 ## v.0.0.32+6
 
 - Ensure that Firebase Test Lab tests have a unique storage bucket for each package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
-## v.0.0.32+8
+## v.0.0.32+7
 
 - Use package:uuid to ensure that Firebase Test Lab tests have a unique results
   directory each time tests are run.
-
-## v.0.0.32+7
-
-- Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.
 
 ## v.0.0.32+6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v.0.0.32+7
 
-- Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.
+- Use package:uuid to ensure that Firebase Test Lab tests have a unique storage
+  bucket each time tests are run.
 
 ## v.0.0.32+6
 

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -84,6 +84,7 @@ class FirebaseTestLabCommand extends PluginCommand {
 
     final List<String> failingPackages = <String>[];
     final List<String> missingFlutterBuild = <String>[];
+    int resultsCounter = 0; // We use a unique GCS bucket for each Firebase Test Lab run
     await for (Directory package in packagesWithTests) {
       // See https://github.com/flutter/flutter/issues/38983
 
@@ -166,7 +167,7 @@ class FirebaseTestLabCommand extends PluginCommand {
           }
           final String buildId = io.Platform.environment['CIRRUS_BUILD_ID'];
           final String resultsDir =
-              'plugins_android_test/$packageName/$buildId';
+              'plugins_android_test/$packageName/$buildId/${resultsCounter++}/';
           final List<String> args = <String>[
             'firebase',
             'test',

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -84,7 +84,8 @@ class FirebaseTestLabCommand extends PluginCommand {
 
     final List<String> failingPackages = <String>[];
     final List<String> missingFlutterBuild = <String>[];
-    int resultsCounter = 0; // We use a unique GCS bucket for each Firebase Test Lab run
+    int resultsCounter =
+        0; // We use a unique GCS bucket for each Firebase Test Lab run
     await for (Directory package in packagesWithTests) {
       // See https://github.com/flutter/flutter/issues/38983
 

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -17,8 +17,8 @@ class FirebaseTestLabCommand extends PluginCommand {
     FileSystem fileSystem, {
     String testRunId,
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : this.testRunId = testRunId ?? Uuid().v4(),
-    super(packagesDir, fileSystem, processRunner: processRunner) {
+  })  : this.testRunId = testRunId ?? Uuid().v4(),
+        super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(
       'project',
       defaultsTo: 'flutter-infra',

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -52,7 +52,7 @@ class FirebaseTestLabCommand extends PluginCommand {
 
   /// A unique identifier for this test run, to prevent directories from being shared between tests.
   ///
-  /// Defaults to `Uuid().v4()`
+  /// Defaults to `Uuid().v4()`.
   final String testRunId;
 
   Future<void> _configureFirebaseProject() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+8
+version: 0.0.32+7
 
 dependencies:
   args: "^1.4.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+7
+version: 0.0.32+8
 
 dependencies:
   args: "^1.4.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+6
+version: 0.0.32+7
 
 dependencies:
   args: "^1.4.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   test: ^1.6.4
   meta: ^1.1.7
   file: ^5.0.10
+  uuid: ^2.0.4
 
 dev_dependencies:
   matcher: ^0.12.6

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -16,7 +16,8 @@ void main() {
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+          processRunner: processRunner,
+          testRunId: 'testRun');
 
       runner = CommandRunner<Null>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
@@ -82,7 +83,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/0/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRun/0/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -92,7 +93,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/1/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRun/1/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -102,7 +103,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/2/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRun/2/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -82,7 +82,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/0/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -92,7 +92,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/1/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -102,7 +102,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/2/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -16,8 +16,7 @@ void main() {
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir, mockFileSystem,
-          processRunner: processRunner,
-          testRunId: 'testRun');
+          processRunner: processRunner, testRunId: 'testRun');
 
       runner = CommandRunner<Null>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');


### PR DESCRIPTION
Prevent Firebase Test Labs flakes by ensuring that bucket identifiers are unique between master and stable runs.

### Related issues

flutter/flutter#46132