### PR TITLE
Disallow breaking changes to platform interfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v.0.0.33
+
+- Version check command now fails on breaking changes to platform interfaces.
+- Updated version check test to be more flexible.
+
 ## v.0.0.32+7
 
 - Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -162,14 +162,14 @@ class VersionCheckCommand extends PluginCommand {
         }
 
         bool isPlatformInterface = pubspec.name.endsWith("_platform_interface");
-        if (allowedNextVersions[headVersion] == NextVersionType.BREAKING_MAJOR) {
+        if (isPlatformInterface && allowedNextVersions[headVersion] ==
+            NextVersionType.BREAKING_MAJOR) {
           final String error = '$pubspecPath breaking change detected.\n'
               'Breaking changes to platform interfaces are strongly discouraged.\n';
           final Colorize redError = Colorize(error)..red();
           print(redError);
           throw ToolExit(1);
         }
-
       } on io.ProcessException {
         print('Unable to find pubspec in master for $pubspecPath.'
             ' Safe to ignore if the project is new.');

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -160,6 +160,16 @@ class VersionCheckCommand extends PluginCommand {
           print(redError);
           throw ToolExit(1);
         }
+
+        bool isPlatformInterface = pubspec.name.endsWith("_platform_interface");
+        if (allowedNextVersions[headVersion] == NextVersionType.BREAKING_MAJOR) {
+          final String error = '$pubspecPath breaking change detected.\n'
+              'Breaking changes to platform interfaces are strongly discouraged.\n';
+          final Colorize redError = Colorize(error)..red();
+          print(redError);
+          throw ToolExit(1);
+        }
+
       } on io.ProcessException {
         print('Unable to find pubspec in master for $pubspecPath.'
             ' Safe to ignore if the project is new.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+7
+version: 0.0.33
 
 dependencies:
   args: "^1.4.3"

--- a/test/util.dart
+++ b/test/util.dart
@@ -35,6 +35,7 @@ Directory createFakePlugin(
   final Directory pluginDirectory = mockPackagesDir.childDirectory(name)
     ..createSync();
   createFakePubspec(
+    name,
     pluginDirectory,
     isFlutter: isFlutter,
     isWebPlugin: isWebPlugin,
@@ -43,14 +44,14 @@ Directory createFakePlugin(
   if (withSingleExample) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
-    createFakePubspec(exampleDir, isFlutter: isFlutter);
+    createFakePubspec("${name}_example", exampleDir, isFlutter: isFlutter);
   } else if (withExamples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     for (String example in withExamples) {
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
-      createFakePubspec(currentExample, isFlutter: isFlutter);
+      createFakePubspec(example, currentExample, isFlutter: isFlutter);
     }
   }
 
@@ -67,6 +68,7 @@ Directory createFakePlugin(
 
 /// Creates a `pubspec.yaml` file with a flutter dependency.
 void createFakePubspec(
+  String name,
   Directory parent, {
   bool isFlutter = true,
   bool includeVersion = false,
@@ -74,7 +76,7 @@ void createFakePubspec(
 }) {
   parent.childFile('pubspec.yaml').createSync();
   String yaml = '''
-name: fake_package
+name: $name
 ''';
   if (isWebPlugin) {
     yaml += '''
@@ -83,7 +85,7 @@ flutter:
     platforms:
       web:
         pluginClass: FakePlugin
-        fileName: fake_plugin_web.dart
+        fileName: ${name}_web.dart
 ''';
   }
   if (isFlutter) {

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -144,7 +144,6 @@ void main() {
     });
 
     test('allows minor changes to platform interfaces', () async {
-      cleanupPackages();
       createFakePlugin('plugin_platform_interface');
       gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
       gitShowResponses = <String, String>{
@@ -173,7 +172,6 @@ void main() {
     });
 
     test('disallows breaking changes to platform interfaces', () async {
-      cleanupPackages();
       createFakePlugin('plugin_platform_interface');
       gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
       gitShowResponses = <String, String>{

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -77,8 +77,8 @@ void main() {
       createFakePlugin('plugin');
       gitDiffResponse = "packages/plugin/pubspec.yaml";
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.0.2',
+        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base_sha=master']);
@@ -148,8 +148,10 @@ void main() {
       createFakePlugin('plugin_platform_interface');
       gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.1.0',
+        'master:packages/plugin_platform_interface/pubspec.yaml':
+            'version: 1.0.0',
+        'HEAD:packages/plugin_platform_interface/pubspec.yaml':
+            'version: 1.1.0',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base_sha=master']);
@@ -158,11 +160,14 @@ void main() {
         orderedEquals(<String>[
           'No version check errors found!',
         ]),
-      );      expect(gitDirCommands.length, equals(3));
+      );
+      expect(gitDirCommands.length, equals(3));
       expect(
           gitDirCommands[0].join(' '), equals('diff --name-only master HEAD'));
-      expect(gitDirCommands[1].join(' '),
-          equals('show master:packages/plugin_platform_interface/pubspec.yaml'));
+      expect(
+          gitDirCommands[1].join(' '),
+          equals(
+              'show master:packages/plugin_platform_interface/pubspec.yaml'));
       expect(gitDirCommands[2].join(' '),
           equals('show HEAD:packages/plugin_platform_interface/pubspec.yaml'));
     });
@@ -172,8 +177,10 @@ void main() {
       createFakePlugin('plugin_platform_interface');
       gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin_platform_interface/pubspec.yaml': 'version: 2.0.0',
+        'master:packages/plugin_platform_interface/pubspec.yaml':
+            'version: 1.0.0',
+        'HEAD:packages/plugin_platform_interface/pubspec.yaml':
+            'version: 2.0.0',
       };
       final Future<List<String>> output = runCapturingPrint(
           runner, <String>['version-check', '--base_sha=master']);
@@ -184,8 +191,10 @@ void main() {
       expect(gitDirCommands.length, equals(3));
       expect(
           gitDirCommands[0].join(' '), equals('diff --name-only master HEAD'));
-      expect(gitDirCommands[1].join(' '),
-          equals('show master:packages/plugin_platform_interface/pubspec.yaml'));
+      expect(
+          gitDirCommands[1].join(' '),
+          equals(
+              'show master:packages/plugin_platform_interface/pubspec.yaml'));
       expect(gitDirCommands[2].join(' '),
           equals('show HEAD:packages/plugin_platform_interface/pubspec.yaml'));
     });

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -38,18 +38,19 @@ void main() {
     CommandRunner<VersionCheckCommand> runner;
     RecordingProcessRunner processRunner;
     List<List<String>> gitDirCommands;
+    String gitDiffResponse;
     Map<String, String> gitShowResponses;
 
     setUp(() {
       gitDirCommands = <List<String>>[];
+      gitDiffResponse = '';
       gitShowResponses = <String, String>{};
       final MockGitDir gitDir = MockGitDir();
       when(gitDir.runCommand(any)).thenAnswer((Invocation invocation) {
         gitDirCommands.add(invocation.positionalArguments[0]);
         final MockProcessResult mockProcessResult = MockProcessResult();
         if (invocation.positionalArguments[0][0] == 'diff') {
-          when<String>(mockProcessResult.stdout)
-              .thenReturn("packages/plugin/pubspec.yaml");
+          when<String>(mockProcessResult.stdout).thenReturn(gitDiffResponse);
         } else if (invocation.positionalArguments[0][0] == 'show') {
           final String response =
               gitShowResponses[invocation.positionalArguments[0][1]];
@@ -68,8 +69,13 @@ void main() {
       runner.addCommand(command);
     });
 
+    tearDown(() {
+      cleanupPackages();
+    });
+
     test('allows valid version', () async {
       createFakePlugin('plugin');
+      gitDiffResponse = "packages/plugin/pubspec.yaml";
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
         'HEAD:packages/plugin/pubspec.yaml': 'version: 0.0.2',
@@ -90,11 +96,11 @@ void main() {
           equals('show master:packages/plugin/pubspec.yaml'));
       expect(gitDirCommands[2].join(' '),
           equals('show HEAD:packages/plugin/pubspec.yaml'));
-      cleanupPackages();
     });
 
     test('denies invalid version', () async {
       createFakePlugin('plugin');
+      gitDiffResponse = "packages/plugin/pubspec.yaml";
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
         'HEAD:packages/plugin/pubspec.yaml': 'version: 0.2.0',
@@ -113,11 +119,11 @@ void main() {
           equals('show master:packages/plugin/pubspec.yaml'));
       expect(gitDirCommands[2].join(' '),
           equals('show HEAD:packages/plugin/pubspec.yaml'));
-      cleanupPackages();
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
       createFakePlugin('plugin');
+      gitDiffResponse = "packages/plugin/pubspec.yaml";
       mockFileSystem.currentDirectory
           .childDirectory('packages')
           .childDirectory('plugin')
@@ -135,7 +141,53 @@ void main() {
       expect(gitDirCommands.length, equals(1));
       expect(gitDirCommands.first.join(' '),
           equals('diff --name-only master HEAD'));
+    });
+
+    test('allows minor changes to platform interfaces', () async {
       cleanupPackages();
+      createFakePlugin('plugin_platform_interface');
+      gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
+      gitShowResponses = <String, String>{
+        'master:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.0.0',
+        'HEAD:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.1.0',
+      };
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base_sha=master']);
+      expect(
+        output,
+        orderedEquals(<String>[
+          'No version check errors found!',
+        ]),
+      );      expect(gitDirCommands.length, equals(3));
+      expect(
+          gitDirCommands[0].join(' '), equals('diff --name-only master HEAD'));
+      expect(gitDirCommands[1].join(' '),
+          equals('show master:packages/plugin_platform_interface/pubspec.yaml'));
+      expect(gitDirCommands[2].join(' '),
+          equals('show HEAD:packages/plugin_platform_interface/pubspec.yaml'));
+    });
+
+    test('disallows breaking changes to platform interfaces', () async {
+      cleanupPackages();
+      createFakePlugin('plugin_platform_interface');
+      gitDiffResponse = "packages/plugin_platform_interface/pubspec.yaml";
+      gitShowResponses = <String, String>{
+        'master:packages/plugin_platform_interface/pubspec.yaml': 'version: 1.0.0',
+        'HEAD:packages/plugin_platform_interface/pubspec.yaml': 'version: 2.0.0',
+      };
+      final Future<List<String>> output = runCapturingPrint(
+          runner, <String>['version-check', '--base_sha=master']);
+      await expectLater(
+        output,
+        throwsA(const TypeMatcher<Error>()),
+      );
+      expect(gitDirCommands.length, equals(3));
+      expect(
+          gitDirCommands[0].join(' '), equals('diff --name-only master HEAD'));
+      expect(gitDirCommands[1].join(' '),
+          equals('show master:packages/plugin_platform_interface/pubspec.yaml'));
+      expect(gitDirCommands[2].join(' '),
+          equals('show HEAD:packages/plugin_platform_interface/pubspec.yaml'));
     });
   });
 


### PR DESCRIPTION
Updates plugins CI to turn red on breaking changes to platform interfaces.

Breaking changes can still be landed on red, but hopefully this check will ensure that there's a discussion about it.

Related https://github.com/flutter/plugins/pull/2560 which was reverted in https://github.com/flutter/plugins/pull/2561