### PR TITLE
firebase test lab command supports a configurable unique string appended to results path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.33
+
+- Firebase Test Lab command generates a configurable unique path suffix for results.
+
 ## v.0.0.32+7
 
 - Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -28,7 +28,9 @@ class FirebaseTestLabCommand extends PluginCommand {
     argParser.addOption('test-run-id',
         defaultsTo: Uuid().v4(),
         help:
-            'Optional string to append to the results path, to avoid conflicts. Randomly chosen if none is provided.');
+            'Optional string to append to the results path, to avoid conflicts. '
+            'Randomly chosen on each invocation if none is provided. '
+            'The default shown here is just an example.');
     argParser.addMultiOption('device',
         splitCommas: false,
         defaultsTo: <String>[

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -7,6 +7,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
 
 import 'common.dart';
 
@@ -24,6 +25,10 @@ class FirebaseTestLabCommand extends PluginCommand {
     argParser.addOption('service-key',
         defaultsTo:
             p.join(io.Platform.environment['HOME'], 'gcloud-service-key.json'));
+    argParser.addOption('test-run-id',
+        defaultsTo: Uuid().v4(),
+        help:
+            'Optional string to append to the results path, to avoid conflicts. Randomly chosen if none is provided.');
     argParser.addMultiOption('device',
         splitCommas: false,
         defaultsTo: <String>[
@@ -167,8 +172,9 @@ class FirebaseTestLabCommand extends PluginCommand {
             continue;
           }
           final String buildId = io.Platform.environment['CIRRUS_BUILD_ID'];
+          final String testRunId = argResults['test-run-id'];
           final String resultsDir =
-              'plugins_android_test/$packageName/$buildId/${resultsCounter++}/';
+              'plugins_android_test/$packageName/$buildId/$testRunId/${resultsCounter++}/';
           final List<String> args = <String>[
             'firebase',
             'test',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+7
+version: 0.0.33
 
 dependencies:
   args: "^1.4.3"
@@ -19,6 +19,7 @@ dependencies:
   test: ^1.6.4
   meta: ^1.1.7
   file: ^5.0.10
+  uuid: ^2.0.4
 
 dev_dependencies:
   matcher: ^0.12.6

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -50,6 +50,8 @@ void main() {
         'model=flame,version=29',
         '--device',
         'model=seoul,version=26',
+        '--test-run-id',
+        'testRunId'
       ]);
 
       expect(
@@ -82,7 +84,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/0/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRunId/0/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -92,7 +94,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/1/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRunId/1/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
           ProcessCall(
@@ -102,7 +104,7 @@ void main() {
               '/packages/plugin/example/android'),
           ProcessCall(
               'gcloud',
-              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/2/ --device model=flame,version=29 --device model=seoul,version=26'
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRunId/2/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),


### PR DESCRIPTION
This ensures that buckets are not shared across test runs within the same build. It's needed because we are testing on both master and stable.