### PR TITLE
firebase test lab flakes: retry gcloud set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v.0.0.33
+
+- Firebase Test Lab command now only tries to configure the project once
+- Firebase Test Lab command now retries project configuration up to five times.
+
 ## v.0.0.32+7
 
 - Ensure that Firebase Test Lab tests have a unique storage bucket for each test run.

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -11,6 +11,8 @@ import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
+typedef void Print(Object object);
+
 /// Returns whether the given directory contains a Flutter package.
 bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
   if (entity == null || entity is! Directory) {

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -16,7 +16,8 @@ class FirebaseTestLabCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
     Print print = print,
-  }) : _print = print, super(packagesDir, fileSystem, processRunner: processRunner) {
+  })  : _print = print,
+        super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(
       'project',
       defaultsTo: 'flutter-infra',
@@ -60,13 +61,13 @@ class FirebaseTestLabCommand extends PluginCommand {
     }
     int attempts = 5;
     for (int i = 0; i < attempts; i++) {
-    int exitCode = await processRunner.runAndStream('gcloud', <String>[
-      'auth',
-      'activate-service-account',
-      '--key-file=${argResults['service-key']}',
-    ]);
+      int exitCode = await processRunner.runAndStream('gcloud', <String>[
+        'auth',
+        'activate-service-account',
+        '--key-file=${argResults['service-key']}',
+      ]);
 
-    if (exitCode == 0) {
+      if (exitCode == 0) {
         exitCode = await processRunner.runAndStream('gcloud', <String>[
           '--quiet',
           'config',
@@ -80,9 +81,10 @@ class FirebaseTestLabCommand extends PluginCommand {
           _firebaseProjectConfigured.complete(null);
           return;
         }
+      }
     }
-    }
-    _print('\nConfiguring Firebase project failed after $attempts attempts. Exiting.');
+    _print(
+        '\nConfiguring Firebase project failed after $attempts attempts. Exiting.');
     throw ToolExit(1);
   }
 

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -15,7 +15,8 @@ class FirebaseTestLabCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    Print print = print,
+  }) : _print = print, super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addOption(
       'project',
       defaultsTo: 'flutter-infra',
@@ -47,28 +48,42 @@ class FirebaseTestLabCommand extends PluginCommand {
 
   static const String _gradleWrapper = 'gradlew';
 
+  final Print _print;
+
+  Completer<void> _firebaseProjectConfigured;
+
   Future<void> _configureFirebaseProject() async {
+    if (_firebaseProjectConfigured != null) {
+      return _firebaseProjectConfigured.future;
+    } else {
+      _firebaseProjectConfigured = Completer<void>();
+    }
+    int attempts = 5;
+    for (int i = 0; i < attempts; i++) {
     int exitCode = await processRunner.runAndStream('gcloud', <String>[
       'auth',
       'activate-service-account',
       '--key-file=${argResults['service-key']}',
     ]);
 
-    if (exitCode != 0) {
-      throw ToolExit(1);
-    }
+    if (exitCode == 0) {
+        exitCode = await processRunner.runAndStream('gcloud', <String>[
+          '--quiet',
+          'config',
+          'set',
+          'project',
+          argResults['project'],
+        ]);
 
-    exitCode = await processRunner.runAndStream('gcloud', <String>[
-      '--quiet',
-      'config',
-      'set',
-      'project',
-      argResults['project'],
-    ]);
-
-    if (exitCode != 0) {
-      throw ToolExit(1);
+        if (exitCode == 0) {
+          _print('\nFirebase project configured.');
+          _firebaseProjectConfigured.complete(null);
+          return;
+        }
     }
+    }
+    _print('\nConfiguring Firebase project failed after $attempts attempts. Exiting.');
+    throw ToolExit(1);
   }
 
   @override
@@ -93,7 +108,7 @@ class FirebaseTestLabCommand extends PluginCommand {
           fileSystem.directory(p.join(package.path, 'example'));
       final String packageName =
           p.relative(package.path, from: packagesDir.path);
-      print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
+      _print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
 
       final Directory androidDirectory =
           fileSystem.directory(p.join(exampleDirectory.path, 'android'));
@@ -199,20 +214,20 @@ class FirebaseTestLabCommand extends PluginCommand {
       }
     }
 
-    print('\n\n');
+    _print('\n\n');
     if (failingPackages.isNotEmpty) {
-      print(
+      _print(
           'The instrumentation tests for the following packages are failing (see above for'
           'details):');
       for (String package in failingPackages) {
-        print(' * $package');
+        _print(' * $package');
       }
     }
     if (missingFlutterBuild.isNotEmpty) {
-      print('Run "pub global run flutter_plugin_tools build-examples --apk" on'
+      _print('Run "pub global run flutter_plugin_tools build-examples --apk" on'
           'the following packages before executing tests again:');
       for (String package in missingFlutterBuild) {
-        print(' * $package');
+        _print(' * $package');
       }
     }
 
@@ -220,6 +235,6 @@ class FirebaseTestLabCommand extends PluginCommand {
       throw ToolExit(1);
     }
 
-    print('All Firebase Test Lab tests successful!');
+    _print('All Firebase Test Lab tests successful!');
   }
 }

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -10,8 +10,6 @@ import 'package:yaml/yaml.dart';
 
 import 'common.dart';
 
-typedef void Print(Object object);
-
 /// Wraps pub publish with a few niceties used by the flutter/plugin team.
 ///
 /// 1. Checks for any modified files in git and refuses to publish if there's an

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+7
+version: 0.0.33
 
 dependencies:
   args: "^1.4.3"

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -1,13 +1,16 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
 import 'util.dart';
 
 void main() {
   group('$FirebaseTestLabCommand', () {
+    final List<String> printedMessages = <String>[];
     CommandRunner<FirebaseTestLabCommand> runner;
     RecordingProcessRunner processRunner;
 
@@ -16,11 +19,41 @@ void main() {
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+          processRunner: processRunner,
+                    print: (Object message) => printedMessages.add(message.toString()));
 
       runner = CommandRunner<Null>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
       runner.addCommand(command);
+    });
+
+    tearDown(() {
+      printedMessages.clear();
+    });
+
+    test('retries gcloud set', () async {
+      final MockProcess mockProcess = MockProcess();
+      mockProcess.exitCodeCompleter.complete(1);
+      processRunner.processToReturn = mockProcess;
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['lib/test/should_not_run_e2e.dart'],
+        <String>['example', 'test_driver', 'plugin_e2e.dart'],
+        <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
+        <String>['example', 'android', 'gradlew'],
+        <String>['example', 'should_not_run_e2e.dart'],
+        <String>[
+          'example',
+          'android',
+          'app',
+          'src',
+          'androidTest',
+          'MainActivityTest.java'
+        ],
+      ]);
+      await expectLater(() => runCapturingPrint(runner, <String>['firebase-test-lab']),
+          throwsA(const TypeMatcher<ToolExit>()));
+      expect(
+          printedMessages.last, contains("\nConfiguring Firebase project failed after 5 attempts. Exiting."));
     });
 
     test('runs e2e tests', () async {
@@ -53,9 +86,10 @@ void main() {
       ]);
 
       expect(
-        output,
+        printedMessages,
         orderedEquals(<String>[
           '\nRUNNING FIREBASE TEST LAB TESTS for plugin',
+          '\nFirebase project configured.',
           '\n\n',
           'All Firebase Test Lab tests successful!',
         ]),
@@ -87,7 +121,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -97,7 +131,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -20,7 +20,7 @@ void main() {
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir, mockFileSystem,
           processRunner: processRunner,
-                    print: (Object message) => printedMessages.add(message.toString()));
+          print: (Object message) => printedMessages.add(message.toString()));
 
       runner = CommandRunner<Null>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
@@ -50,10 +50,13 @@ void main() {
           'MainActivityTest.java'
         ],
       ]);
-      await expectLater(() => runCapturingPrint(runner, <String>['firebase-test-lab']),
+      await expectLater(
+          () => runCapturingPrint(runner, <String>['firebase-test-lab']),
           throwsA(const TypeMatcher<ToolExit>()));
       expect(
-          printedMessages.last, contains("\nConfiguring Firebase project failed after 5 attempts. Exiting."));
+          printedMessages.last,
+          contains(
+              "\nConfiguring Firebase project failed after 5 attempts. Exiting."));
     });
 
     test('runs e2e tests', () async {

--- a/test/util.dart
+++ b/test/util.dart
@@ -145,7 +145,8 @@ class RecordingProcessRunner extends ProcessRunner {
     bool exitOnError = false,
   }) async {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
-    return Future<int>.value(processToReturn == null ? 0 : await processToReturn.exitCode);
+    return Future<int>.value(
+        processToReturn == null ? 0 : await processToReturn.exitCode);
   }
 
   /// Returns [io.ProcessResult] created from [processToReturn], [resultStdout], and [resultStderr].

--- a/test/util.dart
+++ b/test/util.dart
@@ -143,9 +143,9 @@ class RecordingProcessRunner extends ProcessRunner {
     List<String> args, {
     Directory workingDir,
     bool exitOnError = false,
-  }) {
+  }) async {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
-    return Future<int>.value(0);
+    return Future<int>.value(processToReturn == null ? 0 : await processToReturn.exitCode);
   }
 
   /// Returns [io.ProcessResult] created from [processToReturn], [resultStdout], and [resultStderr].
@@ -173,9 +173,17 @@ class RecordingProcessRunner extends ProcessRunner {
     String executable,
     List<String> args, {
     Directory workingDir,
-  }) {
+  }) async {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
-    return Future<io.ProcessResult>.value(null);
+    io.ProcessResult result;
+    if (processToReturn != null) {
+      result = io.ProcessResult(
+          processToReturn.pid,
+          await processToReturn.exitCode,
+          resultStdout ?? processToReturn.stdout,
+          resultStderr ?? processToReturn.stderr);
+    }
+    return Future<io.ProcessResult>.value(result);
   }
 
   @override


### PR DESCRIPTION
We've been seeing frequent timeouts calling gcloud set. This ensures that configuration is only done once (instead of once per package), and retries up to 5 times before giving up.

I'm hoping we can close out the flakes issues below if the build is green after landing this.

Related issues

https://github.com/flutter/flutter/issues/46132
https://github.com/flutter/flutter/issues/46656