### PR TITLE
Make gcloud set verbose to show error messages. Allow builder to continue past gcloud set failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v.0.0.36
+
+- Remove retry on Firebase Test Lab's call to gcloud set.
+- Make Firebase Test Lab's gcloud set command verbose to show error messages.
+- Allow Firebase Test Lab command to continue past gcloud set failures.
+  This is a mitigation for the network service sometimes not responding,
+  but it isn't actually necessary to have a network connection for this command.
+
 ## v.0.0.35+1
 
 - Minor cleanup to the analyze test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## v.0.0.36
 
 - Remove retry on Firebase Test Lab's call to gcloud set.
-- Make Firebase Test Lab's gcloud set command verbose to show error messages.
-- Allow Firebase Test Lab command to continue past gcloud set failures.
+- Remove quiet flag from Firebase Test Lab's gcloud set command.
+- Allow Firebase Test Lab command to continue past gcloud set network failures.
   This is a mitigation for the network service sometimes not responding,
   but it isn't actually necessary to have a network connection for this command.
 

--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -81,7 +81,8 @@ class FirebaseTestLabCommand extends PluginCommand {
       _print('\nFirebase project configured.');
       return;
     } else {
-      _print('\nWarning: gcloud config set returned a non-zero exit code. Continuing anyway.');
+      _print(
+          '\nWarning: gcloud config set returned a non-zero exit code. Continuing anyway.');
     }
     _firebaseProjectConfigured.complete(null);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.35+1
+version: 0.0.36
 
 dependencies:
   args: "^1.4.3"

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -108,8 +108,8 @@ void main() {
               'auth activate-service-account --key-file=${Platform.environment['HOME']}/gcloud-service-key.json'
                   .split(' '),
               null),
-          ProcessCall('gcloud',
-              'config set project flutter-infra'.split(' '), null),
+          ProcessCall(
+              'gcloud', 'config set project flutter-infra'.split(' '), null),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -54,9 +54,9 @@ void main() {
           () => runCapturingPrint(runner, <String>['firebase-test-lab']),
           throwsA(const TypeMatcher<ToolExit>()));
       expect(
-          printedMessages.last,
+          printedMessages,
           contains(
-              "\nConfiguring Firebase project failed after 5 attempts. Exiting."));
+              "\nWarning: gcloud config set returned a non-zero exit code. Continuing anyway."));
     });
 
     test('runs e2e tests', () async {
@@ -109,7 +109,7 @@ void main() {
                   .split(' '),
               null),
           ProcessCall('gcloud',
-              '--quiet config set project flutter-infra'.split(' '), null),
+              'config set project flutter-infra'.split(' '), null),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),


### PR DESCRIPTION
Despite the 5 retries, we're still failing to call gcloud set. However in my local testing I've noticed that the network response isn't necessary for gcloud set to succeed. So now we're displaying a warning instead of failing.

https://cirrus-ci.com/task/4663814192889856?command=main#L4980