### PR TITLE
Adds support for flutter build/drive for Windows packages

### DIFF
--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -16,6 +16,7 @@ class BuildExamplesCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addFlag('windows', defaultsTo: false);
     argParser.addFlag('macos', defaultsTo: false);
     argParser.addFlag('ipa', defaultsTo: io.Platform.isMacOS);
     argParser.addFlag('apk');
@@ -31,8 +32,8 @@ class BuildExamplesCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
-    if (!argResults['ipa'] && !argResults['apk'] && !argResults['macos']) {
-      print('Neither --macos, --apk nor --ipa were specified, so not building '
+    if (!argResults['ipa'] && !argResults['apk'] && !argResults['macos'] && !argResults['windows']) {
+      print('Neither --windows, --macos, --apk nor --ipa were specified, so not building '
           'anything.');
       return;
     }
@@ -66,6 +67,23 @@ class BuildExamplesCommand extends PluginCommand {
             workingDir: example);
         if (exitCode != 0) {
           failingPackages.add('$packageName (macos)');
+        }
+      }
+
+      if (argResults['windows']) {
+        print('\nBUILDING windows for $packageName');
+        final Directory windowsDir =
+            fileSystem.directory(p.join(example.path, 'windows'));
+        if (!windowsDir.existsSync()) {
+          print('No Windows implementation found.');
+          continue;
+        }
+
+        int exitCode = await processRunner.runAndStream(
+            'flutter', <String>['build', 'windows'],
+            workingDir: example);
+        if (exitCode != 0) {
+          failingPackages.add('$packageName (windows)');
         }
       }
 

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -84,24 +84,24 @@ class BuildExamplesCommand extends PluginCommand {
             // with 'flutter create .'
             final Directory windowsFolder =
                 fileSystem.directory(p.join(example.path, 'windows'));
-            if (windowsFolder.existsSync()) {
-              windowsFolder.deleteSync(recursive: true);
-            }
-            int exitCode = await processRunner.runAndStream(
-                flutterCommand, <String>['create', '.'],
-                workingDir: example);
-            if (exitCode != 0) {
-              failingPackages.add('$packageName (windows)');
-            } else {
-              exitCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['build', kWindows],
+            bool exampleCreated = false;
+            if (!windowsFolder.existsSync()) {
+              int exampleCreateCode = await processRunner.runAndStream(
+                  flutterCommand, <String>['create', '.'],
                   workingDir: example);
-              if (exitCode != 0) {
-                failingPackages.add('$packageName (windows)');
+              if (exampleCreateCode == 0) {
+                exampleCreated = true;
               }
-              if (windowsFolder.existsSync()) {
-                windowsFolder.deleteSync(recursive: true);
-              }
+            }
+            int buildExitCode = await processRunner.runAndStream(
+                flutterCommand, <String>['build', kWindows],
+                workingDir: example);
+            if (buildExitCode != 0) {
+              failingPackages.add('$packageName (windows)');
+            }
+
+            if (exampleCreated && windowsFolder.existsSync()) {
+              windowsFolder.deleteSync(recursive: true);
             }
           } else {
             print('Windows is not supported by this plugin');

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -71,32 +71,32 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (argResults[kWindows]) {
           print('\nBUILDING windows for $packageName');
-          print(example);
           if (isWindowsPlugin(plugin, fileSystem)) {
+            // The Windows tooling is not yet stable, so we need to
+            // delete any existing windows directory and create a new one
+            // with 'flutter create .'
             final Directory windowsFolder =
               fileSystem.directory(p.join(example.path, 'windows'));
             if (windowsFolder.existsSync()) {
-              print('deleting');
-              windowsFolder.deleteSync();
+              windowsFolder.deleteSync(recursive: true);
             }
-            print('Trying ===');
-            print(example.existsSync());
-            final int createCode = await processRunner.runAndStream(
-                'flutter', <String>['create', '.'],
-                workingDir: example);
-                print('Create code: $createCode');
-
-            final int exitCode = await processRunner.runAndStream(
-                'flutter', <String>['build', kWindows],
+            int exitCode = await processRunner.runAndStream(
+                'flutter.bat', <String>['create', '.'],
                 workingDir: example);
             if (exitCode != 0) {
-              print('Exit code $exitCode');
               failingPackages.add('$packageName (windows)');
+            } else {
+              exitCode = await processRunner.runAndStream(
+                  'flutter.bat', <String>['build', kWindows],
+                  workingDir: example);
+              if (exitCode != 0) {
+                failingPackages.add('$packageName (windows)');
+              }
+              windowsFolder.deleteSync(recursive: true);
             }
           } else {
             print('Windows is not supported by this plugin');
           }
-          print('afger');
         }
 
         if (argResults[kIpa]) {

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -7,6 +7,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 import 'common.dart';
 
@@ -37,6 +38,7 @@ class BuildExamplesCommand extends PluginCommand {
           'anything.');
       return;
     }
+    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     checkSharding();
     final List<String> failingPackages = <String>[];
@@ -52,13 +54,13 @@ class BuildExamplesCommand extends PluginCommand {
             // Builing macos without running flutter pub get first results
             // in an error.
             int exitCode = await processRunner.runAndStream(
-                'flutter', <String>['pub', 'get'],
+                flutterCommand, <String>['pub', 'get'],
                 workingDir: example);
             if (exitCode != 0) {
               failingPackages.add('$packageName (macos)');
             } else {
               exitCode = await processRunner.runAndStream(
-                'flutter', <String>['build', kMacos],
+                flutterCommand, <String>['build', kMacos],
                 workingDir: example);
               if (exitCode != 0) {
                 failingPackages.add('$packageName (macos)');
@@ -81,13 +83,13 @@ class BuildExamplesCommand extends PluginCommand {
               windowsFolder.deleteSync(recursive: true);
             }
             int exitCode = await processRunner.runAndStream(
-                'flutter.bat', <String>['create', '.'],
+                flutterCommand, <String>['create', '.'],
                 workingDir: example);
             if (exitCode != 0) {
               failingPackages.add('$packageName (windows)');
             } else {
               exitCode = await processRunner.runAndStream(
-                  'flutter.bat', <String>['build', kWindows],
+                  flutterCommand, <String>['build', kWindows],
                   workingDir: example);
               if (exitCode != 0) {
                 failingPackages.add('$packageName (windows)');
@@ -104,7 +106,7 @@ class BuildExamplesCommand extends PluginCommand {
         if (argResults[kIpa]) {
           print('\nBUILDING IPA for $packageName');
           final int exitCode = await processRunner.runAndStream(
-              'flutter', <String>['build', 'ios', '--no-codesign'],
+              flutterCommand, <String>['build', 'ios', '--no-codesign'],
               workingDir: example);
           if (exitCode != 0) {
             failingPackages.add('$packageName (ipa)');
@@ -114,7 +116,7 @@ class BuildExamplesCommand extends PluginCommand {
         if (argResults[kApk]) {
           print('\nBUILDING APK for $packageName');
           final int exitCode = await processRunner.runAndStream(
-              'flutter', <String>['build', 'apk'],
+              flutterCommand, <String>['build', 'apk'],
               workingDir: example);
           if (exitCode != 0) {
             failingPackages.add('$packageName (apk)');

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -40,13 +40,15 @@ class BuildExamplesCommand extends PluginCommand {
 
     checkSharding();
     final List<String> failingPackages = <String>[];
+    print('Before plugins');
     await for (Directory plugin in getPlugins()) {
+      print(plugin);
       for (Directory example in getExamplesForPlugin(plugin)) {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
 
         if (argResults[kMacos]) {
-          print('\nBUILDING macos for $packageName');;
+          print('\nBUILDING macos for $packageName');
           if (isMacOsPlugin(plugin, fileSystem)) {
             // TODO(https://github.com/flutter/flutter/issues/46236):
             // Builing macos without running flutter pub get first results

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -10,11 +10,6 @@ import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
-const String kWindows = 'windows';
-const String kMacos = 'macos';
-const String kIpa = 'ipa';
-const String kApk = 'apk';
-
 class BuildExamplesCommand extends PluginCommand {
   BuildExamplesCommand(
     Directory packagesDir,

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -33,12 +33,17 @@ class BuildExamplesCommand extends PluginCommand {
 
   @override
   Future<Null> run() async {
-    if (!argResults[kIpa] && !argResults[kApk] && !argResults[kMacos] && !argResults[kWindows]) {
-      print('None of --windows, --macos, --apk nor --ipa were specified, so not building '
+    if (!argResults[kIpa] &&
+        !argResults[kApk] &&
+        !argResults[kMacos] &&
+        !argResults[kWindows]) {
+      print(
+          'None of --windows, --macos, --apk nor --ipa were specified, so not building '
           'anything.');
       return;
     }
-    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+    final String flutterCommand =
+        LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     checkSharding();
     final List<String> failingPackages = <String>[];
@@ -60,8 +65,8 @@ class BuildExamplesCommand extends PluginCommand {
               failingPackages.add('$packageName (macos)');
             } else {
               exitCode = await processRunner.runAndStream(
-                flutterCommand, <String>['build', kMacos],
-                workingDir: example);
+                  flutterCommand, <String>['build', kMacos],
+                  workingDir: example);
               if (exitCode != 0) {
                 failingPackages.add('$packageName (macos)');
               }
@@ -78,7 +83,7 @@ class BuildExamplesCommand extends PluginCommand {
             // delete any existing windows directory and create a new one
             // with 'flutter create .'
             final Directory windowsFolder =
-              fileSystem.directory(p.join(example.path, 'windows'));
+                fileSystem.directory(p.join(example.path, 'windows'));
             if (windowsFolder.existsSync()) {
               windowsFolder.deleteSync(recursive: true);
             }

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -40,9 +40,7 @@ class BuildExamplesCommand extends PluginCommand {
 
     checkSharding();
     final List<String> failingPackages = <String>[];
-    print('Before plugins');
     await for (Directory plugin in getPlugins()) {
-      print(plugin);
       for (Directory example in getExamplesForPlugin(plugin)) {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
@@ -94,7 +92,9 @@ class BuildExamplesCommand extends PluginCommand {
               if (exitCode != 0) {
                 failingPackages.add('$packageName (windows)');
               }
-              windowsFolder.deleteSync(recursive: true);
+              if (windowsFolder.existsSync()) {
+                windowsFolder.deleteSync(recursive: true);
+              }
             }
           } else {
             print('Windows is not supported by this plugin');

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -33,7 +33,7 @@ class BuildExamplesCommand extends PluginCommand {
   @override
   Future<Null> run() async {
     if (!argResults[kIpa] && !argResults[kApk] && !argResults[kMacos] && !argResults[kWindows]) {
-      print('Neither --windows, --macos, --apk nor --ipa were specified, so not building '
+      print('None of --windows, --macos, --apk nor --ipa were specified, so not building '
           'anything.');
       return;
     }

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -99,7 +99,6 @@ class BuildExamplesCommand extends PluginCommand {
             if (buildExitCode != 0) {
               failingPackages.add('$packageName (windows)');
             }
-
             if (exampleCreated && windowsFolder.existsSync()) {
               windowsFolder.deleteSync(recursive: true);
             }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -19,11 +19,24 @@ const String kWindows = 'windows';
 /// Key for macos platform.
 const String kMacos = 'macos';
 
-/// Key for ipa platform.
+/// Key for linux platform.
+const String kLinux = 'linux';
+
+/// Key for IPA (iOS) platform.
+const String kIos = 'ios';
+
+/// Key for APK (Android) platform.
+const String kAndroid = 'android';
+
+/// Key for Web platform.
+const String kWeb = 'web';
+
+/// Key for IPA.
 const String kIpa = 'ipa';
 
-/// Key for apk platform.
+/// Key for APK.
 const String kApk = 'apk';
+
 
 /// Returns whether the given directory contains a Flutter package.
 bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
@@ -57,12 +70,12 @@ bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
 ///           [platform]:
 bool pluginSupportsPlatform(
     String platform, FileSystemEntity entity, FileSystem fileSystem) {
-  assert(platform == 'ios' ||
-      platform == 'android' ||
-      platform == 'web' ||
-      platform == 'macos' ||
-      platform == 'windows' ||
-      platform == 'linux');
+  assert(platform == kIos ||
+      platform == kAndroid ||
+      platform == kWeb ||
+      platform == kMacos ||
+      platform == kWindows ||
+      platform == kLinux);
   if (entity == null || entity is! Directory) {
     return false;
   }
@@ -93,22 +106,22 @@ bool pluginSupportsPlatform(
 
 /// Returns whether the given directory contains a Flutter web plugin.
 bool isWebPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform('web', entity, fileSystem);
+  return pluginSupportsPlatform(kWeb, entity, fileSystem);
 }
 
 /// Returns whether the given directory contains a Flutter Windows plugin.
 bool isWindowsPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform('windows', entity, fileSystem);
+  return pluginSupportsPlatform(kWindows, entity, fileSystem);
 }
 
 /// Returns whether the given directory contains a Flutter macOS plugin.
 bool isMacOsPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform('macos', entity, fileSystem);
+  return pluginSupportsPlatform(kMacos, entity, fileSystem);
 }
 
 /// Returns whether the given directory contains a Flutter linux plugin.
 bool isLinuxPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform('linux', entity, fileSystem);
+  return pluginSupportsPlatform(kLinux, entity, fileSystem);
 }
 
 /// Error thrown when a command needs to exit with a non-zero exit code.

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -61,7 +61,6 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity, FileSystem
     platform == 'linux'
   );
   if (entity == null || entity is! Directory) {
-    print('Bad entity');
     return false;
   }
 
@@ -69,9 +68,6 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity, FileSystem
     final File pubspecFile =
         fileSystem.file(p.join(entity.path, 'pubspec.yaml'));
     final YamlMap pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
-    if (platform == 'windows') {
-      print(pubspecYaml);
-    }
     final YamlMap flutterSection = pubspecYaml['flutter'];
     if (flutterSection == null) {
       return false;
@@ -81,9 +77,6 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity, FileSystem
       return false;
     }
     final YamlMap platforms = pluginSection['platforms'];
-    if (platform == 'windows') {
-      print(platforms);
-    }
     if (platforms == null) {
       return false;
     }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -212,7 +212,6 @@ abstract class PluginCommand extends Command<Null> {
         (allPlugins.length % shardCount == 0 ? 0 : 1);
     final int start = min(shardIndex * shardSize, allPlugins.length);
     final int end = min(start + shardSize, allPlugins.length);
-        print('All Plugins $allPlugins');
 
     for (Directory plugin in allPlugins.sublist(start, end)) {
       yield plugin;
@@ -234,27 +233,18 @@ abstract class PluginCommand extends Command<Null> {
   ///    "client library" package, which declares the API for the plugin, as
   ///    well as one or more platform-specific implementations.
   Stream<Directory> _getAllPlugins() async* {
-    print('argResult ${argResults.arguments}');
-    print(_pluginsArg);
     final Set<String> plugins = Set<String>.from(argResults[_pluginsArg]);
-    print('plugins: $plugins');
     await for (FileSystemEntity entity
         in packagesDir.list(followLinks: false)) {
-          print(entity);
       // A top-level Dart package is a plugin package.
       if (_isDartPackage(entity)) {
-        print('Is dart package');
         if (plugins.isEmpty || plugins.contains(p.basename(entity.path))) {
-          print('Is empty $plugins');
           yield entity;
         }
       } else if (entity is Directory) {
-        print('Is directory');
         // Look for Dart packages under this top-level directory.
         await for (FileSystemEntity subdir in entity.list(followLinks: false)) {
-          print('Sub idr $subdir');
           if (_isDartPackage(subdir)) {
-            print('Sub is Dart package');
             // If --plugin=my_plugin is passed, then match all federated
             // plugins under 'my_plugin'. Also match if the exact plugin is
             // passed.

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -12,12 +12,16 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 typedef void Print(Object object);
+
 /// Key for windows platform.
 const String kWindows = 'windows';
+
 /// Key for macos platform.
 const String kMacos = 'macos';
+
 /// Key for ipa platform.
 const String kIpa = 'ipa';
+
 /// Key for apk platform.
 const String kApk = 'apk';
 
@@ -51,15 +55,14 @@ bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
 ///       plugin:
 ///         platforms:
 ///           [platform]:
-bool pluginSupportsPlatform(String platform, FileSystemEntity entity, FileSystem fileSystem) {
-  assert(
-    platform == 'ios' ||
-    platform == 'android' ||
-    platform == 'web' ||
-    platform == 'macos' ||
-    platform == 'windows' ||
-    platform == 'linux'
-  );
+bool pluginSupportsPlatform(
+    String platform, FileSystemEntity entity, FileSystem fileSystem) {
+  assert(platform == 'ios' ||
+      platform == 'android' ||
+      platform == 'web' ||
+      platform == 'macos' ||
+      platform == 'windows' ||
+      platform == 'linux');
   if (entity == null || entity is! Directory) {
     return false;
   }
@@ -92,6 +95,7 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity, FileSystem
 bool isWebPlugin(FileSystemEntity entity, FileSystem fileSystem) {
   return pluginSupportsPlatform('web', entity, fileSystem);
 }
+
 /// Returns whether the given directory contains a Flutter Windows plugin.
 bool isWindowsPlugin(FileSystemEntity entity, FileSystem fileSystem) {
   return pluginSupportsPlatform('windows', entity, fileSystem);

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -260,12 +260,6 @@ abstract class PluginCommand extends Command<Null> {
     }
   }
 
-  /// Checks if a [platform] directory exists in a [directory].
-  bool platformDirectoryExists(String platform, Directory directory) {
-    final Directory dir = fileSystem.directory(p.join(directory.path, platform));
-    return dir.existsSync();
-  }
-
   /// Returns the example Dart package folders of the plugins involved in this
   /// command execution.
   Stream<Directory> getExamples() =>

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -12,6 +12,14 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 typedef void Print(Object object);
+/// Key for windows platform.
+const String kWindows = 'windows';
+/// Key for macos platform.
+const String kMacos = 'macos';
+/// Key for ipa platform.
+const String kIpa = 'ipa';
+/// Key for apk platform.
+const String kApk = 'apk';
 
 /// Returns whether the given directory contains a Flutter package.
 bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -212,6 +212,8 @@ abstract class PluginCommand extends Command<Null> {
         (allPlugins.length % shardCount == 0 ? 0 : 1);
     final int start = min(shardIndex * shardSize, allPlugins.length);
     final int end = min(start + shardSize, allPlugins.length);
+        print('All Plugins $allPlugins');
+
     for (Directory plugin in allPlugins.sublist(start, end)) {
       yield plugin;
     }
@@ -232,18 +234,27 @@ abstract class PluginCommand extends Command<Null> {
   ///    "client library" package, which declares the API for the plugin, as
   ///    well as one or more platform-specific implementations.
   Stream<Directory> _getAllPlugins() async* {
+    print('argResult ${argResults.arguments}');
+    print(_pluginsArg);
     final Set<String> plugins = Set<String>.from(argResults[_pluginsArg]);
+    print('plugins: $plugins');
     await for (FileSystemEntity entity
         in packagesDir.list(followLinks: false)) {
+          print(entity);
       // A top-level Dart package is a plugin package.
       if (_isDartPackage(entity)) {
+        print('Is dart package');
         if (plugins.isEmpty || plugins.contains(p.basename(entity.path))) {
+          print('Is empty $plugins');
           yield entity;
         }
       } else if (entity is Directory) {
+        print('Is directory');
         // Look for Dart packages under this top-level directory.
         await for (FileSystemEntity subdir in entity.list(followLinks: false)) {
+          print('Sub idr $subdir');
           if (_isDartPackage(subdir)) {
+            print('Sub is Dart package');
             // If --plugin=my_plugin is passed, then match all federated
             // plugins under 'my_plugin'. Also match if the exact plugin is
             // passed.

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -224,6 +224,12 @@ abstract class PluginCommand extends Command<Null> {
     }
   }
 
+  /// Checks if a [platform] directory exists in a [directory].
+  bool platformDirectoryExists(String platform, Directory directory) {
+    final Directory dir = fileSystem.directory(p.join(directory.path, platform));
+    return dir.existsSync();
+  }
+
   /// Returns the example Dart package folders of the plugins involved in this
   /// command execution.
   Stream<Directory> getExamples() =>

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -43,7 +43,7 @@ bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
   }
 }
 
-/// Returns whether the given directory contains a Flutter web plugin.
+/// Returns whether the given directory contains a Flutter [platform] plugin.
 ///
 /// It checks this by looking for the following pattern in the pubspec:
 ///

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -37,7 +37,6 @@ const String kIpa = 'ipa';
 /// Key for APK.
 const String kApk = 'apk';
 
-
 /// Returns whether the given directory contains a Flutter package.
 bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
   if (entity == null || entity is! Directory) {

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -30,13 +30,6 @@ class DriveExamplesCommand extends PluginCommand {
       'For example, test_driver/app_test.dart would match test/app.dart.\n\n'
       'This command requires "flutter" to be in your path.';
 
-  bool _platformDirectoryExists(String platform, Directory directory) {
-    assert(platform == 'macos' ||
-           platform == 'windows');
-    final Directory dir = fileSystem.directory(p.join(directory.path, platform));
-    return dir.existsSync();
-  }
-
   @override
   Future<Null> run() async {
     checkSharding();
@@ -48,12 +41,12 @@ class DriveExamplesCommand extends PluginCommand {
           p.relative(example.path, from: packagesDir.path);
       // If macos is specified, filter out plugins that don't have a macos implementation yet.
       if (isMacos) {
-        if (_platformDirectoryExists('macos', example)) {
+        if (platformDirectoryExists('macos', example)) {
           continue;
         }
       }
       if (isWindows) {
-        if (_platformDirectoryExists('windows', example)) {
+        if (platformDirectoryExists('windows', example)) {
           continue;
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -13,9 +13,9 @@ class DriveExamplesCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
-    argParser.addFlag('macos',
+    argParser.addFlag(kMacos,
         help: 'Runs the macOS implementation of the examples');
-    argParser.addFlag('windows',
+    argParser.addFlag(kWindows,
         help: 'Runs the Windows implementation of the examples');
   }
 
@@ -33,19 +33,19 @@ class DriveExamplesCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingTests = <String>[];
-    final bool isMacos = argResults['macos'];
-    final bool isWindows = argResults['windows'];
+    final bool isMacos = argResults[kMacos];
+    final bool isWindows = argResults[kWindows];
     await for (Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
       // Filter out plugins that don't have the required platform implementation yet.
       if (isMacos) {
-        if (platformDirectoryExists('macos', example)) {
+        if (platformDirectoryExists(kMacos, example)) {
           continue;
         }
       }
       if (isWindows) {
-        if (platformDirectoryExists('windows', example)) {
+        if (platformDirectoryExists(kWindows, example)) {
           continue;
         }
       }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 import 'common.dart';

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -79,7 +79,7 @@ class DriveExamplesCommand extends PluginCommand {
         await for (FileSystemEntity test in driverTests.list()) {
           final String driverTestName =
               p.relative(test.path, from: driverTests.path);
-          if (!driverTestName.endsWith("_test.dart")) {
+          if (!driverTestName.endsWith('_test.dart')) {
             continue;
           }
           // Try to find a matching app to drive without the _test.dart

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -40,7 +40,8 @@ class DriveExamplesCommand extends PluginCommand {
       for (Directory example in getExamplesForPlugin(plugin)) {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
-        final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+        final String flutterCommand =
+            LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
         if (isMacos) {
           if (!isMacOsPlugin(plugin, fileSystem)) {
@@ -53,7 +54,7 @@ class DriveExamplesCommand extends PluginCommand {
             // delete any existing windows directory and create a new one
             // with 'flutter create .'
             final Directory windowsFolder =
-              fileSystem.directory(p.join(example.path, 'windows'));
+                fileSystem.directory(p.join(example.path, 'windows'));
             if (windowsFolder.existsSync()) {
               windowsFolder.deleteSync(recursive: true);
             }

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -38,7 +38,7 @@ class DriveExamplesCommand extends PluginCommand {
     await for (Directory example in getExamples()) {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
-      // If macos is specified, filter out plugins that don't have a macos implementation yet.
+      // Filter out plugins that don't have the required platform implementation yet.
       if (isMacos) {
         if (platformDirectoryExists('macos', example)) {
           continue;

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -55,15 +55,14 @@ class DriveExamplesCommand extends PluginCommand {
             // with 'flutter create .'
             final Directory windowsFolder =
                 fileSystem.directory(p.join(example.path, 'windows'));
-            if (windowsFolder.existsSync()) {
-              windowsFolder.deleteSync(recursive: true);
-            }
-            int exitCode = await processRunner.runAndStream(
-                flutterCommand, <String>['create', '.'],
-                workingDir: example);
-            if (exitCode != 0) {
-              print('Failed to create a windows directory for $packageName');
-              continue;
+            if (!windowsFolder.existsSync()) {
+              int exitCode = await processRunner.runAndStream(
+                  flutterCommand, <String>['create', '.'],
+                  workingDir: example);
+              if (exitCode != 0) {
+                print('Failed to create a windows directory for $packageName');
+                continue;
+              }
             }
           } else {
             continue;

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -41,16 +41,17 @@ class DriveExamplesCommand extends PluginCommand {
             p.relative(example.path, from: packagesDir.path);
         String flutterCommand = 'flutter';
 
-        // Filter out plugins that don't have the required platform implementation yet.
-        if (isMacos && !isMacOsPlugin(plugin, fileSystem)) {
-          continue;
+        if (isMacos) {
+          if (!isMacOsPlugin(plugin, fileSystem)) {
+            continue;
+          }
         }
-
-        if (isWindows && isWindowsPlugin(plugin, fileSystem)) {
-          flutterCommand = 'flutter.bat';
-          // The Windows tooling is not yet stable, so we need to
-          // delete any existing windows directory and create a new one
-          // with 'flutter create .'
+        if (isWindows) {
+          if (isWindowsPlugin(plugin, fileSystem)) {
+            flutterCommand = 'flutter.bat';
+            // The Windows tooling is not yet stable, so we need to
+            // delete any existing windows directory and create a new one
+            // with 'flutter create .'
             final Directory windowsFolder =
               fileSystem.directory(p.join(example.path, 'windows'));
             if (windowsFolder.existsSync()) {
@@ -63,8 +64,9 @@ class DriveExamplesCommand extends PluginCommand {
               print('Failed to create a windows directory for $packageName');
               continue;
             }
-        } else {
-          continue;
+          } else {
+            continue;
+          }
         }
 
         final Directory driverTests =
@@ -101,13 +103,13 @@ class DriveExamplesCommand extends PluginCommand {
           }
 
           final List<String> driveArgs = <String>['drive'];
-          if (isMacos) {
+          if (isMacos && isMacOsPlugin(plugin, fileSystem)) {
             driveArgs.addAll(<String>[
               '-d',
               'macos',
             ]);
           }
-          if (isWindows) {
+          if (isWindows && isWindowsPlugin(plugin, fileSystem)) {
             driveArgs.addAll(<String>[
               '-d',
               'windows',

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'common.dart';
 
 class DriveExamplesCommand extends PluginCommand {
@@ -39,7 +40,7 @@ class DriveExamplesCommand extends PluginCommand {
       for (Directory example in getExamplesForPlugin(plugin)) {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
-        String flutterCommand = 'flutter';
+        final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
         if (isMacos) {
           if (!isMacOsPlugin(plugin, fileSystem)) {
@@ -48,7 +49,6 @@ class DriveExamplesCommand extends PluginCommand {
         }
         if (isWindows) {
           if (isWindowsPlugin(plugin, fileSystem)) {
-            flutterCommand = 'flutter.bat';
             // The Windows tooling is not yet stable, so we need to
             // delete any existing windows directory and create a new one
             // with 'flutter create .'

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -39,16 +39,14 @@ class DriveExamplesCommand extends PluginCommand {
       final String packageName =
           p.relative(example.path, from: packagesDir.path);
       // Filter out plugins that don't have the required platform implementation yet.
-      if (isMacos) {
-        if (platformDirectoryExists(kMacos, example)) {
-          continue;
-        }
+      if (isMacos && !isMacOsPlugin(example, fileSystem)) {
+        continue;
       }
-      if (isWindows) {
-        if (platformDirectoryExists(kWindows, example)) {
-          continue;
-        }
+
+      if (isWindows && !isWindowsPlugin(example, fileSystem)) {
+        continue;
       }
+
       final Directory driverTests =
           fileSystem.directory(p.join(example.path, 'test_driver'));
       if (!driverTests.existsSync()) {

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -208,7 +208,9 @@ void main() {
       cleanupPackages();
     });
 
-    test('runs build for windows does not call flutter create if a directory exists', () async {
+    test(
+        'runs build for windows does not call flutter create if a directory exists',
+        () async {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -11,7 +11,8 @@ void main() {
   group('test build_example_command', () {
     CommandRunner<Null> runner;
     RecordingProcessRunner processRunner;
-    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+    final String flutterCommand =
+        LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     setUp(() {
       initializeFakePackages();
@@ -54,7 +55,9 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['build', 'ios', '--no-codesign'],
+            ProcessCall(
+                flutterCommand,
+                <String>['build', 'ios', '--no-codesign'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -93,10 +96,12 @@ void main() {
       cleanupPackages();
     });
     test('runs build for macos', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test'],
-        <String>['example', 'macos', 'macos.swift'],
-      ], isMacOsPlugin: true);
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+            <String>['example', 'macos', 'macos.swift'],
+          ],
+          isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -121,19 +126,22 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(
-                flutterCommand, <String>['pub', 'get'], pluginExampleDirectory.path),
+            ProcessCall(flutterCommand, <String>['pub', 'get'],
+                pluginExampleDirectory.path),
             ProcessCall(flutterCommand, <String>['build', 'macos'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
     });
 
-    test('runs build for Windows when plugin is not setup for Windows results in no-op',
+    test(
+        'runs build for Windows when plugin is not setup for Windows results in no-op',
         () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], isWindowsPlugin: false);
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+          isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -163,9 +171,11 @@ void main() {
     });
 
     test('runs build for windows', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], isWindowsPlugin: true);
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+          isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -190,8 +200,8 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(
-                flutterCommand, <String>['create', '.'], pluginExampleDirectory.path),
+            ProcessCall(flutterCommand, <String>['create', '.'],
+                pluginExampleDirectory.path),
             ProcessCall(flutterCommand, <String>['build', 'windows'],
                 pluginExampleDirectory.path),
           ]));

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -2,6 +2,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -10,6 +11,7 @@ void main() {
   group('test build_example_command', () {
     CommandRunner<Null> runner;
     RecordingProcessRunner processRunner;
+    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     setUp(() {
       initializeFakePackages();
@@ -52,7 +54,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['build', 'ios', '--no-codesign'],
+            ProcessCall(flutterCommand, <String>['build', 'ios', '--no-codesign'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -120,8 +122,8 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                'flutter', <String>['pub', 'get'], pluginExampleDirectory.path),
-            ProcessCall('flutter', <String>['build', 'macos'],
+                flutterCommand, <String>['pub', 'get'], pluginExampleDirectory.path),
+            ProcessCall(flutterCommand, <String>['build', 'macos'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -224,7 +226,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['build', 'apk'],
+            ProcessCall(flutterCommand, <String>['build', 'apk'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -191,8 +191,8 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                'flutter.bat', <String>['create', '.'], pluginExampleDirectory.path),
-            ProcessCall('flutter.bat', <String>['build', 'windows'],
+                flutterCommand, <String>['create', '.'], pluginExampleDirectory.path),
+            ProcessCall(flutterCommand, <String>['build', 'windows'],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -139,7 +139,7 @@ void main() {
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--windows']);
+          runner, <String>['build-examples', '--no-ipa', '--windows']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
 
@@ -171,7 +171,7 @@ void main() {
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--windows']);
+          runner, <String>['build-examples', '--no-ipa', '--windows']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
 

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -241,7 +241,9 @@ void main() {
 
       cleanupPackages();
     });
-    test('runs drive on a Windows plugin with a windows direactory does not call flutter create', () async {
+    test(
+        'runs drive on a Windows plugin with a windows direactory does not call flutter create',
+        () async {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -224,11 +224,11 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                'flutter.bat',
+                flutterCommand,
                 <String>['create', '.'],
                 pluginExampleDirectory.path),
             ProcessCall(
-                'flutter.bat',
+                flutterCommand,
                 <String>['drive', '-d', 'windows', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -46,11 +47,12 @@ void main() {
         ]),
       );
 
+      String deviceTestPath = p.join('test', 'plugin.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['drive', 'test/plugin.dart'],
+            ProcessCall('flutter', <String>['drive', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -79,17 +81,18 @@ void main() {
         ]),
       );
 
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['drive', 'test_driver/plugin.dart'],
+            ProcessCall('flutter', <String>['drive', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));
 
       cleanupPackages();
     });
-    test('runs drive with no macos implementation', () async {
+    test('runs drive when plugin does not suppport macOS is a no-op', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
@@ -120,12 +123,12 @@ void main() {
 
       cleanupPackages();
     });
-    test('runs drive with a macOS implementation', () async {
+    test('runs drive on a macOS plugin', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
         <String>['example', 'macos', 'macos.swift'],
-      ]);
+      ], isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -145,13 +148,87 @@ void main() {
         ]),
       );
 
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 'flutter',
-                <String>['drive', '-d', 'macos', 'test_driver/plugin.dart'],
+                <String>['drive', '-d', 'macos', deviceTestPath],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
+    test('runs drive when plugin does not suppport windows is a no-op', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], isMacOsPlugin: false);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--windows',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // Output should be empty since running drive-examples --windows on a non-windows
+      // plugin is a no-op.
+      expect(processRunner.recordedCalls, <ProcessCall>[]);
+
+      cleanupPackages();
+    });
+
+    test('runs drive on a Windows plugin', () async {
+      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], isWindowsPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--windows',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                'flutter.bat',
+                <String>['create', '.'],
+                pluginExampleDirectory.path),
+            ProcessCall(
+                'flutter.bat',
+                <String>['drive', '-d', 'windows', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));
 

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -241,5 +241,46 @@ void main() {
 
       cleanupPackages();
     });
+    test('runs drive on a Windows plugin with a windows direactory does not call flutter create', () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+            <String>['example', 'windows', 'test.h'],
+          ],
+          isWindowsPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--windows',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      print(processRunner.recordedCalls);
+      // flutter create . should NOT be called.
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                flutterCommand,
+                <String>['drive', '-d', 'windows', deviceTestPath],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
   });
 }

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -11,7 +11,8 @@ void main() {
   group('test drive_example_command', () {
     CommandRunner<Null> runner;
     RecordingProcessRunner processRunner;
-    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+    final String flutterCommand =
+        LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
     setUp(() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
@@ -125,11 +126,13 @@ void main() {
       cleanupPackages();
     });
     test('runs drive on a macOS plugin', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-        <String>['example', 'macos', 'macos.swift'],
-      ], isMacOsPlugin: true);
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+            <String>['example', 'macos', 'macos.swift'],
+          ],
+          isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -162,11 +165,14 @@ void main() {
 
       cleanupPackages();
     });
-    test('runs drive when plugin does not suppport windows is a no-op', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], isMacOsPlugin: false);
+    test('runs drive when plugin does not suppport windows is a no-op',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+          ],
+          isMacOsPlugin: false);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -195,10 +201,12 @@ void main() {
     });
 
     test('runs drive on a Windows plugin', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], isWindowsPlugin: true);
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+          ],
+          isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -223,9 +231,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(
-                flutterCommand,
-                <String>['create', '.'],
+            ProcessCall(flutterCommand, <String>['create', '.'],
                 pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -2,6 +2,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -10,7 +11,7 @@ void main() {
   group('test drive_example_command', () {
     CommandRunner<Null> runner;
     RecordingProcessRunner processRunner;
-
+    final String flutterCommand = LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
     setUp(() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
@@ -52,7 +53,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['drive', deviceTestPath],
+            ProcessCall(flutterCommand, <String>['drive', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -86,7 +87,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('flutter', <String>['drive', deviceTestPath],
+            ProcessCall(flutterCommand, <String>['drive', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));
 
@@ -154,7 +155,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                'flutter',
+                flutterCommand,
                 <String>['drive', '-d', 'macos', deviceTestPath],
                 pluginExampleDirectory.path),
           ]));

--- a/test/util.dart
+++ b/test/util.dart
@@ -4,20 +4,21 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:platform/platform.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:quiver/collection.dart';
 
-FileSystem mockFileSystem = MemoryFileSystem();
+FileSystem mockFileSystem = MemoryFileSystem(
+    style: LocalPlatform().isWindows
+        ? FileSystemStyle.windows
+        : FileSystemStyle.posix);
 Directory mockPackagesDir;
 
 /// Creates a mock packages directory in the mock file system.
 ///
 /// If [parentDir] is set the mock packages dir will be creates as a child of
 /// it. If not [mockFileSystem] will be used instead.
-void initializeFakePackages({Directory parentDir, FileSystem mockFs}) {
-  if (mockFileSystem != null) {
-    mockFileSystem = mockFs ?? mockFileSystem;
-  }
+void initializeFakePackages({Directory parentDir}) {
   mockPackagesDir =
       (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
   mockPackagesDir.createSync();

--- a/test/util.dart
+++ b/test/util.dart
@@ -28,6 +28,8 @@ Directory createFakePlugin(
   List<List<String>> withExtraFiles = const <List<String>>[],
   bool isFlutter = true,
   bool isWebPlugin = false,
+  bool isMacOsPlugin = false,
+  bool isWindowsPlugin = false,
 }) {
   assert(!(withSingleExample && withExamples.isNotEmpty),
       'cannot pass withSingleExample and withExamples simultaneously');
@@ -39,7 +41,10 @@ Directory createFakePlugin(
     name: name,
     isFlutter: isFlutter,
     isWebPlugin: isWebPlugin,
+    isMacOsPlugin: isMacOsPlugin,
+    isWindowsPlugin: isWindowsPlugin,
   );
+  print(pluginDirectory);
 
   if (withSingleExample) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
@@ -70,23 +75,37 @@ Directory createFakePlugin(
 /// Creates a `pubspec.yaml` file with a flutter dependency.
 void createFakePubspec(
   Directory parent, {
-  String name: 'fake_package',
+  String name = 'fake_package',
   bool isFlutter = true,
   bool includeVersion = false,
   bool isWebPlugin = false,
+  bool isMacOsPlugin = false,
+  bool isWindowsPlugin = false,
 }) {
   parent.childFile('pubspec.yaml').createSync();
   String yaml = '''
 name: $name
-''';
-  if (isWebPlugin) {
-    yaml += '''
 flutter:
   plugin:
     platforms:
+''';
+  if (isWebPlugin) {
+    yaml += '''
       web:
         pluginClass: FakePlugin
         fileName: ${name}_web.dart
+''';
+  }
+  if (isMacOsPlugin) {
+    yaml += '''
+      macos:
+        pluginClass: FakePlugin
+''';
+  }
+if (isWindowsPlugin) {
+    yaml += '''
+      windows:
+        pluginClass: FakePlugin
 ''';
   }
   if (isFlutter) {
@@ -102,6 +121,7 @@ version: 0.0.1
 publish_to: none # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }
+print(yaml);
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);
 }
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -105,7 +105,7 @@ flutter:
         pluginClass: FakePlugin
 ''';
   }
-if (isWindowsPlugin) {
+  if (isWindowsPlugin) {
     yaml += '''
       windows:
         pluginClass: FakePlugin

--- a/test/util.dart
+++ b/test/util.dart
@@ -7,14 +7,17 @@ import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:quiver/collection.dart';
 
-final FileSystem mockFileSystem = MemoryFileSystem();
+FileSystem mockFileSystem = MemoryFileSystem();
 Directory mockPackagesDir;
 
 /// Creates a mock packages directory in the mock file system.
 ///
 /// If [parentDir] is set the mock packages dir will be creates as a child of
 /// it. If not [mockFileSystem] will be used instead.
-void initializeFakePackages({Directory parentDir}) {
+void initializeFakePackages({Directory parentDir, FileSystem mockFs}) {
+  if (mockFileSystem != null) {
+    mockFileSystem = mockFs ?? mockFileSystem;
+  }
   mockPackagesDir =
       (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
   mockPackagesDir.createSync();
@@ -44,7 +47,6 @@ Directory createFakePlugin(
     isMacOsPlugin: isMacOsPlugin,
     isWindowsPlugin: isWindowsPlugin,
   );
-  print(pluginDirectory);
 
   if (withSingleExample) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
@@ -121,7 +123,6 @@ version: 0.0.1
 publish_to: none # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }
-print(yaml);
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);
 }
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/41719

Adds a `windows` flag to both `build/drive_examples_command.dart`. Only packages with a `windows` directory will run the command. 

Also updates the logic for macOS and Windows, checking whether the platform is supported in the pubspec.yaml, rather than checking if a directory exists.
Added tools to detect the platform.