### PR TITLE
Bump version for showing podspec lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.36+2
+
+- Default to showing podspec lint warnings
+
 ## v.0.0.36+1
 
 - Serialize linting podspecs.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.36+1
+version: 0.0.36+2
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Forgot to bump version for https://github.com/flutter/plugin_tools/pull/97.