### PR TITLE
Adds support for flutter build/drive for Linux packages

### DIFF
--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -14,6 +14,8 @@ class DriveExamplesCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addFlag(kLinux,
+        help: 'Runs the Linux implementation of the examples');
     argParser.addFlag(kMacos,
         help: 'Runs the macOS implementation of the examples');
     argParser.addFlag(kWindows,
@@ -34,6 +36,7 @@ class DriveExamplesCommand extends PluginCommand {
   Future<Null> run() async {
     checkSharding();
     final List<String> failingTests = <String>[];
+    final bool isLinux = argResults[kLinux];
     final bool isMacos = argResults[kMacos];
     final bool isWindows = argResults[kWindows];
     await for (Directory plugin in getPlugins()) {
@@ -43,6 +46,26 @@ class DriveExamplesCommand extends PluginCommand {
         final String flutterCommand =
             LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
+        if (isLinux) {
+          if (isLinuxPlugin(plugin, fileSystem)) {
+            // The Linux tooling is not yet stable, so we need to
+            // delete any existing linux directory and create a new one
+            // with 'flutter create .'
+            final Directory linuxFolder =
+                fileSystem.directory(p.join(example.path, 'linux'));
+            if (!linuxFolder.existsSync()) {
+              int exitCode = await processRunner.runAndStream(
+                  flutterCommand, <String>['create', '.'],
+                  workingDir: example);
+              if (exitCode != 0) {
+                print('Failed to create a linux directory for $packageName');
+                continue;
+              }
+            }
+          } else {
+            continue;
+          }
+        }
         if (isMacos) {
           if (!isMacOsPlugin(plugin, fileSystem)) {
             continue;
@@ -103,6 +126,12 @@ class DriveExamplesCommand extends PluginCommand {
           }
 
           final List<String> driveArgs = <String>['drive'];
+          if (isLinux && isLinuxPlugin(plugin, fileSystem)) {
+            driveArgs.addAll(<String>[
+              '-d',
+              'linux',
+            ]);
+          }
           if (isMacos && isMacOsPlugin(plugin, fileSystem)) {
             driveArgs.addAll(<String>[
               '-d',

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -47,23 +47,22 @@ class DriveExamplesCommand extends PluginCommand {
             LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
         if (isLinux) {
-          if (isLinuxPlugin(plugin, fileSystem)) {
-            // The Linux tooling is not yet stable, so we need to
-            // delete any existing linux directory and create a new one
-            // with 'flutter create .'
-            final Directory linuxFolder =
-                fileSystem.directory(p.join(example.path, 'linux'));
-            if (!linuxFolder.existsSync()) {
-              int exitCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['create', '.'],
-                  workingDir: example);
-              if (exitCode != 0) {
-                print('Failed to create a linux directory for $packageName');
-                continue;
-              }
-            }
-          } else {
+          if (!isLinuxPlugin(plugin, fileSystem)) {
             continue;
+          }
+          // The Linux tooling is not yet stable, so we need to
+          // delete any existing linux directory and create a new one
+          // with 'flutter create .'
+          final Directory linuxFolder =
+              fileSystem.directory(p.join(example.path, 'linux'));
+          if (!linuxFolder.existsSync()) {
+            int exitCode = await processRunner.runAndStream(
+                flutterCommand, <String>['create', '.'],
+                workingDir: example);
+            if (exitCode != 0) {
+              print('Failed to create a linux directory for $packageName');
+              continue;
+            }
           }
         }
         if (isMacos) {
@@ -72,23 +71,22 @@ class DriveExamplesCommand extends PluginCommand {
           }
         }
         if (isWindows) {
-          if (isWindowsPlugin(plugin, fileSystem)) {
-            // The Windows tooling is not yet stable, so we need to
-            // delete any existing windows directory and create a new one
-            // with 'flutter create .'
-            final Directory windowsFolder =
-                fileSystem.directory(p.join(example.path, 'windows'));
-            if (!windowsFolder.existsSync()) {
-              int exitCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['create', '.'],
-                  workingDir: example);
-              if (exitCode != 0) {
-                print('Failed to create a windows directory for $packageName');
-                continue;
-              }
-            }
-          } else {
+          if (!isWindowsPlugin(plugin, fileSystem)) {
             continue;
+          }
+          // The Windows tooling is not yet stable, so we need to
+          // delete any existing windows directory and create a new one
+          // with 'flutter create .'
+          final Directory windowsFolder =
+              fileSystem.directory(p.join(example.path, 'windows'));
+          if (!windowsFolder.existsSync()) {
+            int exitCode = await processRunner.runAndStream(
+                flutterCommand, <String>['create', '.'],
+                workingDir: example);
+            if (exitCode != 0) {
+              print('Failed to create a windows directory for $packageName');
+              continue;
+            }
           }
         }
 

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -63,6 +63,120 @@ void main() {
       cleanupPackages();
     });
 
+    test(
+        'runs build for Linux when plugin is not setup for Linux results in no-op',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+          isLinuxPlugin: false);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-ipa', '--linux']);
+      final String packageName =
+          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING Linux for $packageName',
+          'Linux is not supported by this plugin',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // Output should be empty since running build-examples --macos with no macos
+      // implementation is a no-op.
+      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+      cleanupPackages();
+    });
+
+    test('runs build for Linux', () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+          isLinuxPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-ipa', '--linux']);
+      final String packageName =
+          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING Linux for $packageName',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(flutterCommand, <String>['create', '.'],
+                pluginExampleDirectory.path),
+            ProcessCall(flutterCommand, <String>['build', 'linux'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+
+    test(
+        'runs build for Linux does not call flutter create if a directory exists',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+            <String>['example', 'linux', 'test.h']
+          ],
+          isLinuxPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['build-examples', '--no-ipa', '--linux']);
+      final String packageName =
+          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\nBUILDING Linux for $packageName',
+          '\n\n',
+          'All builds successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // flutter create . should NOT be called.
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(flutterCommand, <String>['build', 'linux'],
+                pluginExampleDirectory.path),
+          ]));
+      cleanupPackages();
+    });
+
     test('runs build for macos with no implementation results in no-op',
         () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
@@ -82,7 +196,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING macos for $packageName',
+          '\nBUILDING macOS for $packageName',
           '\macOS is not supported by this plugin',
           '\n\n',
           'All builds successful!',
@@ -116,7 +230,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING macos for $packageName',
+          '\nBUILDING macOS for $packageName',
           '\n\n',
           'All builds successful!',
         ]),
@@ -156,7 +270,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING windows for $packageName',
+          '\nBUILDING Windows for $packageName',
           'Windows is not supported by this plugin',
           '\n\n',
           'All builds successful!',
@@ -190,7 +304,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING windows for $packageName',
+          '\nBUILDING Windows for $packageName',
           '\n\n',
           'All builds successful!',
         ]),
@@ -231,7 +345,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING windows for $packageName',
+          '\nBUILDING Windows for $packageName',
           '\n\n',
           'All builds successful!',
         ]),

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -95,8 +95,7 @@ void main() {
       cleanupPackages();
     });
 
-    test('runs drive when plugin does not suppport Linux is a no-op',
-        () async {
+    test('runs drive when plugin does not suppport Linux is a no-op', () async {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -94,6 +94,128 @@ void main() {
 
       cleanupPackages();
     });
+
+    test('runs drive when plugin does not suppport Linux is a no-op',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+          ],
+          isMacOsPlugin: false);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--linux',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      print(processRunner.recordedCalls);
+      // Output should be empty since running drive-examples --linux on a non-Linux
+      // plugin is a no-op.
+      expect(processRunner.recordedCalls, <ProcessCall>[]);
+
+      cleanupPackages();
+    });
+
+    test('runs drive on a Linux plugin', () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+          ],
+          isLinuxPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--linux',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(flutterCommand, <String>['create', '.'],
+                pluginExampleDirectory.path),
+            ProcessCall(
+                flutterCommand,
+                <String>['drive', '-d', 'linux', deviceTestPath],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
+
+    test(
+        'runs drive on a Linux plugin with a Linux direactory does not call flutter create',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+            <String>['example', 'linux', 'test.h'],
+          ],
+          isLinuxPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--linux',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      print(processRunner.recordedCalls);
+      // flutter create . should NOT be called.
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                flutterCommand,
+                <String>['drive', '-d', 'linux', deviceTestPath],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
+
     test('runs drive when plugin does not suppport macOS is a no-op', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],

--- a/test/util.dart
+++ b/test/util.dart
@@ -32,6 +32,7 @@ Directory createFakePlugin(
   List<List<String>> withExtraFiles = const <List<String>>[],
   bool isFlutter = true,
   bool isWebPlugin = false,
+  bool isLinuxPlugin = false,
   bool isMacOsPlugin = false,
   bool isWindowsPlugin = false,
 }) {
@@ -45,6 +46,7 @@ Directory createFakePlugin(
     name: name,
     isFlutter: isFlutter,
     isWebPlugin: isWebPlugin,
+    isLinuxPlugin: isLinuxPlugin,
     isMacOsPlugin: isMacOsPlugin,
     isWindowsPlugin: isWindowsPlugin,
   );
@@ -82,6 +84,7 @@ void createFakePubspec(
   bool isFlutter = true,
   bool includeVersion = false,
   bool isWebPlugin = false,
+  bool isLinuxPlugin = false,
   bool isMacOsPlugin = false,
   bool isWindowsPlugin = false,
 }) {
@@ -97,6 +100,12 @@ flutter:
       web:
         pluginClass: FakePlugin
         fileName: ${name}_web.dart
+''';
+  }
+  if (isLinuxPlugin) {
+    yaml += '''
+      linux:
+        pluginClass: FakePlugin
 ''';
   }
   if (isMacOsPlugin) {


### PR DESCRIPTION
Adds pre-release support for testing Linux plugin implementations. This uses all the same logic as https://github.com/flutter/plugin_tools/pull/95, but s/Windows/Linux/, since like Windows the Linux runners are not yet stabilized so shouldn't be checked in.