### PR TITLE
all-plugins-app use depedency_overrides instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.32+7
+
+- All_plugin test puts the plugin dependencies into dependency_overrides.
+
 ## v.0.0.32+6
 
 - Ensure that Firebase Test Lab tests have a unique storage bucket for each package.

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -156,12 +156,11 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       dependencies: <String, Dependency>{
         'flutter': SdkDependency('flutter'),
       },
-      dependencyOverrides: await _getValidPathDependencies(),
       devDependencies: <String, Dependency>{
         'flutter_test': SdkDependency('flutter'),
       },
+      dependencyOverrides: (await _getValidPathDependencies()),
     );
-
     final File pubspecFile =
         fileSystem.file(p.join('all_plugins', 'pubspec.yaml'));
     pubspecFile.writeAsStringSync(_pubspecToString(pubspec));
@@ -185,7 +184,6 @@ class CreateAllPluginsAppCommand extends PluginCommand {
         pathDependencies[pluginName] = PathDependency(package.path);
       }
     }
-
     return pathDependencies;
   }
 
@@ -200,6 +198,8 @@ version: ${pubspec.version}
 environment:${_pubspecMapString(pubspec.environment)}
 
 dependencies:${_pubspecMapString(pubspec.dependencies)}
+
+dependency_overrides:${_pubspecMapString(pubspec.dependencyOverrides)}
 
 dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
 ###''';

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -143,6 +143,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _genPubspecWithAllPlugins() async {
+    final Map<String, PathDependency> pluginDeps = await _getValidPathDependencies();
     final Pubspec pubspec = Pubspec(
       'all_plugins',
       description: 'Flutter app containing all 1st party plugins.',
@@ -154,11 +155,11 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       },
       dependencies: <String, Dependency>{
         'flutter': SdkDependency('flutter'),
-      },
+      }..addAll(pluginDeps),
       devDependencies: <String, Dependency>{
         'flutter_test': SdkDependency('flutter'),
       },
-      dependencyOverrides: (await _getValidPathDependencies()),
+      dependencyOverrides: pluginDeps,
     );
     final File pubspecFile =
         fileSystem.file(p.join('all_plugins', 'pubspec.yaml'));

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -143,7 +143,8 @@ class CreateAllPluginsAppCommand extends PluginCommand {
   }
 
   Future<void> _genPubspecWithAllPlugins() async {
-    final Map<String, PathDependency> pluginDeps = await _getValidPathDependencies();
+    final Map<String, PathDependency> pluginDeps =
+        await _getValidPathDependencies();
     final Pubspec pubspec = Pubspec(
       'all_plugins',
       description: 'Flutter app containing all 1st party plugins.',

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -12,6 +12,8 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'common.dart';
 
+// TODO(cyanglaz): Add tests for this command.
+// https://github.com/flutter/flutter/issues/61049
 class CreateAllPluginsAppCommand extends PluginCommand {
   CreateAllPluginsAppCommand(Directory packagesDir, FileSystem fileSystem)
       : super(packagesDir, fileSystem) {
@@ -153,7 +155,8 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       },
       dependencies: <String, Dependency>{
         'flutter': SdkDependency('flutter'),
-      }..addAll(await _getValidPathDependencies()),
+      },
+      dependencyOverrides: await _getValidPathDependencies(),
       devDependencies: <String, Dependency>{
         'flutter_test': SdkDependency('flutter'),
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.0.37+1
 dependencies:
   args: "^1.4.3"
   path: "^1.6.1"
-  http: "^0.11.3+17"
+  http: "0.12.1"
   async: "^2.0.7"
   yaml: "^2.1.15"
   quiver: "^2.0.2"
@@ -19,6 +19,7 @@ dependencies:
   meta: ^1.1.7
   file: ^5.0.10
   uuid: ^2.0.4
+  http_multi_server: 2.2.0
 
 dev_dependencies:
   matcher: ^0.12.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.32+6
+version: 0.0.32+7
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Use `dependency` directly with path causes the test to fail if a first party plugin depends on another first party plugin. This will fix it.
We might be able to remove some of the plugins from https://github.com/flutter/plugins/blob/master/script/build_all_plugins_app.sh#L13 after this fix.


cc @bparrishMines Do you know what is the excluding list for?