### PR TITLE
Fix the pub publish warning about pinging dep version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.37+2
+
+- Make `http` and `http_multi_server` dependency version constraint more flexible.
+
 ## v.0.0.37+1
 
 - All_plugin test puts the plugin dependencies into dependency_overrides.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.37+1
+version: 0.0.37+2
 
 dependencies:
   args: "^1.4.3"
   path: "^1.6.1"
-  http: "0.12.1"
+  http: "^0.12.1"
   async: "^2.0.7"
   yaml: "^2.1.15"
   quiver: "^2.0.2"
@@ -19,7 +19,7 @@ dependencies:
   meta: ^1.1.7
   file: ^5.0.10
   uuid: ^2.0.4
-  http_multi_server: 2.2.0
+  http_multi_server: ^2.2.0
 
 dev_dependencies:
   matcher: ^0.12.6


### PR DESCRIPTION
Loose up the version constraint so the `pub publish` won't warn.