### PR TITLE
Support integration_test/ directory for package:integration_test

### DIFF
--- a/lib/src/firebase_test_lab_command.dart
+++ b/lib/src/firebase_test_lab_command.dart
@@ -151,7 +151,8 @@ class FirebaseTestLabCommand extends PluginCommand {
       // Look for tests recursively in folders that start with 'test' and that
       // live in the root or example folders.
       bool isTestDir(FileSystemEntity dir) {
-        return p.basename(dir.path).startsWith('test');
+        return p.basename(dir.path).startsWith('test') ||
+            p.basename(dir.path) == 'integration_test';
       }
 
       final List<FileSystemEntity> testDirs =
@@ -161,7 +162,9 @@ class FirebaseTestLabCommand extends PluginCommand {
       testDirs.addAll(example.listSync().where(isTestDir).toList());
       for (Directory testDir in testDirs) {
         bool isE2ETest(FileSystemEntity file) {
-          return file.path.endsWith('_e2e.dart');
+          return file.path.endsWith('_e2e.dart') ||
+              (file.parent.basename == 'integration_test' &&
+                  file.path.endsWith('_test.dart'));
         }
 
         final List<FileSystemEntity> testFiles = testDir

--- a/test/firebase_test_lab_test.dart
+++ b/test/firebase_test_lab_test.dart
@@ -68,6 +68,8 @@ void main() {
         <String>['example', 'test', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
+        <String>['example', 'integration_test', 'foo_test.dart'],
+        <String>['example', 'integration_test', 'should_not_run.dart'],
         <String>['example', 'android', 'gradlew'],
         <String>['example', 'should_not_run_e2e.dart'],
         <String>[
@@ -142,6 +144,16 @@ void main() {
           ProcessCall(
               'gcloud',
               'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRunId/2/ --device model=flame,version=29 --device model=seoul,version=26'
+                  .split(' '),
+              '/packages/plugin/example'),
+          ProcessCall(
+              '/packages/plugin/example/android/gradlew',
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/integration_test/foo_test.dart'
+                  .split(' '),
+              '/packages/plugin/example/android'),
+          ProcessCall(
+              'gcloud',
+              'firebase test android run --type instrumentation --app build/app/outputs/apk/debug/app-debug.apk --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk --timeout 5m --results-bucket=gs://flutter_firebase_testlab --results-dir=plugins_android_test/plugin/null/testRunId/3/ --device model=flame,version=29 --device model=seoul,version=26'
                   .split(' '),
               '/packages/plugin/example'),
         ]),


### PR DESCRIPTION
In flutter/plugins#2986, and flutter/flutter#64690, we want to drop the `_e2e.dart` suffix from test code, and tell users to place them in the `integration_test/` directory. This PR adds support so that tests in this directory will run on FTL.