### PR TITLE
Add C++ and ObjC++ to formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.38
+
+- Add C++ and ObjC++ to clang-format.
+
 ## v.0.0.37+2
 
 - Make `http` and `http_multi_server` dependency version constraint more flexible.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As an example, Flutter Plugin Tools allows you to:
 
 * Build all plugin example apps with one command
 * Run the tests of all plugins with one command
-* Format all Dart, Java, and Objective-C code in the repository
+* Format all Dart, Java, Objective-C, and C++ code in the repository
 * Define shards of the above tasks
 
 ## Installation

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -33,7 +33,7 @@ class FormatCommand extends PluginCommand {
 
   @override
   final String description =
-      'Formats the code of all packages (Java, Objective-C, and Dart).\n\n'
+      'Formats the code of all packages (Java, Objective-C, C++, and Dart).\n\n'
       'This command requires "git", "flutter" and "clang-format" v5 to be in '
       'your path.';
 
@@ -44,7 +44,7 @@ class FormatCommand extends PluginCommand {
 
     await _formatDart();
     await _formatJava(googleFormatterPath);
-    await _formatObjectiveC();
+    await _formatCppAndObjectiveC();
 
     if (argResults['travis']) {
       final bool modified = await _didModifyAnything();
@@ -83,15 +83,16 @@ class FormatCommand extends PluginCommand {
     return true;
   }
 
-  Future<Null> _formatObjectiveC() async {
-    print('Formatting all .m and .h files...');
-    final Iterable<String> hFiles = await _getFilesWithExtension('.h');
-    final Iterable<String> mFiles = await _getFilesWithExtension('.m');
-    // Split this into multiple invocations to avoid a
-    // 'ProcessException: Argument list too long'
+  Future<Null> _formatCppAndObjectiveC() async {
+    print('Formatting all .cc, .cpp, .mm, .m, and .h files...');
     final Iterable<String> allFiles = <String>[]
-      ..addAll(hFiles)
-      ..addAll(mFiles);
+      ..addAll(await _getFilesWithExtension('.h'))
+      ..addAll(await _getFilesWithExtension('.m'))
+      ..addAll(await _getFilesWithExtension('.mm'))
+      ..addAll(await _getFilesWithExtension('.cc'))
+      ..addAll(await _getFilesWithExtension('.cpp'));
+    // Split this into multiple invocations to avoid a
+    // 'ProcessException: Argument list too long'.
     final Iterable<List<String>> batches = partition(allFiles, 100);
     for (List<String> batch in batches) {
       await processRunner.runAndStream(argResults['clang-format'],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.37+2
+version: 0.0.38
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Adds C++ files (for Linux and Windows plugins) to clang-format
invocation.

Also adds ObjC++ (.mm) files; while there are not currently any in the
repository, there is no reason a plugin couldn't use ObjC++ in the
future.