### PR TITLE
Support integration_test directory for drive command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.40
+
+- Support `integration_test/` directory for `drive-examples` command
+
 ## v.0.0.39
 
 - Support `integration_test/` directory for `package:integration_test`

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -35,8 +35,9 @@ class DriveExamplesCommand extends PluginCommand {
       'corresponding name in the test/ or test_driver/ directories.\n\n'
       'For example, test_driver/app_test.dart would match test/app.dart.\n\n'
       'This command requires "flutter" to be in your path.\n\n'
-      'If a file with a corresponding name cannot be found, it will reuse'
-      'this file to drive the tests that match integration_test/*_test.dart.';
+      'If a file with a corresponding name cannot be found, this driver file'
+      'will be used to drive the tests that match '
+      'integration_test/*_test.dart.';
 
   @override
   Future<Null> run() async {
@@ -131,8 +132,13 @@ class DriveExamplesCommand extends PluginCommand {
             }
 
             if (targetPaths.isEmpty) {
-              print(
-                  'Unable to find an application for $driverTestName to drive');
+              print('''
+Unable to infer a target application for $driverTestName to drive.
+Tried searching for the following:
+1. test/$deviceTestName
+2. test_driver/$deviceTestName
+3. test_driver/*_test.dart
+''');
               failingTests.add(p.relative(test.path, from: example.path));
               continue;
             }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.39
+version: 0.0.40
 
 dependencies:
   args: "^1.4.3"

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
@@ -53,11 +54,20 @@ void main() {
       );
 
       String deviceTestPath = p.join('test', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['drive', deviceTestPath],
+            ProcessCall(
+                flutterCommand,
+                <String>[
+                  'drive',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
       cleanupPackages();
@@ -90,11 +100,100 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['drive', deviceTestPath],
+            ProcessCall(
+                flutterCommand,
+                <String>[
+                  'drive',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
+                pluginExampleDirectory.path),
+          ]));
+
+      cleanupPackages();
+    });
+
+    test('driving under folder "test_driver" when test files are missing"',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+          ],
+          isAndroidPlugin: true,
+          isIosPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      await expectLater(
+          () => runCapturingPrint(runner, <String>['drive-examples']),
+          throwsA(const TypeMatcher<ToolExit>()));
+      cleanupPackages();
+    });
+
+    test(
+        'driving under folder "test_driver" when targets are under "integration_test"',
+        () async {
+      createFakePlugin('plugin',
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'integration_test.dart'],
+            <String>['example', 'integration_test', 'bar_test.dart'],
+            <String>['example', 'integration_test', 'foo_test.dart'],
+            <String>['example', 'integration_test', 'ignore_me.dart'],
+          ],
+          isAndroidPlugin: true,
+          isIosPlugin: true);
+
+      final Directory pluginExampleDirectory =
+          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+      ]);
+
+      expect(
+        output,
+        orderedEquals(<String>[
+          '\n\n',
+          'All driver tests successful!',
+        ]),
+      );
+
+      String driverTestPath = p.join('test_driver', 'integration_test.dart');
+      print(processRunner.recordedCalls);
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                flutterCommand,
+                <String>[
+                  'drive',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  p.join('integration_test', 'bar_test.dart'),
+                ],
+                pluginExampleDirectory.path),
+            ProcessCall(
+                flutterCommand,
+                <String>[
+                  'drive',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  p.join('integration_test', 'foo_test.dart'),
+                ],
                 pluginExampleDirectory.path),
           ]));
 
@@ -162,6 +261,7 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
@@ -170,7 +270,15 @@ void main() {
                 pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,
-                <String>['drive', '-d', 'linux', deviceTestPath],
+                <String>[
+                  'drive',
+                  '-d',
+                  'linux',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
 
@@ -207,6 +315,7 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       // flutter create . should NOT be called.
       expect(
@@ -214,7 +323,15 @@ void main() {
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>['drive', '-d', 'linux', deviceTestPath],
+                <String>[
+                  'drive',
+                  '-d',
+                  'linux',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
 
@@ -280,13 +397,22 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>['drive', '-d', 'macos', deviceTestPath],
+                <String>[
+                  'drive',
+                  '-d',
+                  'macos',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
 
@@ -353,6 +479,7 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       expect(
           processRunner.recordedCalls,
@@ -361,7 +488,15 @@ void main() {
                 pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,
-                <String>['drive', '-d', 'windows', deviceTestPath],
+                <String>[
+                  'drive',
+                  '-d',
+                  'windows',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
 
@@ -397,6 +532,7 @@ void main() {
       );
 
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
+      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
       // flutter create . should NOT be called.
       expect(
@@ -404,7 +540,15 @@ void main() {
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>['drive', '-d', 'windows', deviceTestPath],
+                <String>[
+                  'drive',
+                  '-d',
+                  'windows',
+                  '--driver',
+                  driverTestPath,
+                  '--target',
+                  deviceTestPath
+                ],
                 pluginExampleDirectory.path),
           ]));
 


### PR DESCRIPTION
For any driver script in `packages/$package/example/test_driver` that ends with `_test.dart`, this plugin will attempt to use this driver script to drive all the files in `packages/$package/example/integration_test/` that end with `_test.dart`.

This also changes the drive CLI command to pass `--target` and `--driver` explicitly, which is a no-op change because this is how the files are inferred by the flutter tool.