### PR TITLE
Remove Linux build workaround

### DIFF
--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -57,28 +57,11 @@ class BuildExamplesCommand extends PluginCommand {
         if (argResults[kLinux]) {
           print('\nBUILDING Linux for $packageName');
           if (isLinuxPlugin(plugin, fileSystem)) {
-            // The Linux tooling is not yet stable, so we need to
-            // delete any existing linux directory and create a new one
-            // with 'flutter create .'
-            final Directory linuxFolder =
-                fileSystem.directory(p.join(example.path, 'linux'));
-            bool exampleCreated = false;
-            if (!linuxFolder.existsSync()) {
-              int exampleCreateCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['create', '.'],
-                  workingDir: example);
-              if (exampleCreateCode == 0) {
-                exampleCreated = true;
-              }
-            }
             int buildExitCode = await processRunner.runAndStream(
                 flutterCommand, <String>['build', kLinux],
                 workingDir: example);
             if (buildExitCode != 0) {
               failingPackages.add('$packageName (linux)');
-            }
-            if (exampleCreated && linuxFolder.existsSync()) {
-              linuxFolder.deleteSync(recursive: true);
             }
           } else {
             print('Linux is not supported by this plugin');

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -52,21 +52,6 @@ class DriveExamplesCommand extends PluginCommand {
         if (!(await pluginSupportedOnCurrentPlatform(plugin, fileSystem))) {
           continue;
         }
-        if (isLinux) {
-          // The Linux tooling is not yet stable, so the platform directory for the application
-          // might not exist, to prevent it from becoming stale. If it doesn't, create one.
-          final Directory linuxFolder =
-              fileSystem.directory(p.join(example.path, 'linux'));
-          if (!linuxFolder.existsSync()) {
-            int exitCode = await processRunner.runAndStream(
-                flutterCommand, <String>['create', '.'],
-                workingDir: example);
-            if (exitCode != 0) {
-              print('Failed to create a linux directory for $packageName');
-              continue;
-            }
-          }
-        }
         if (isWindows) {
           // The Windows tooling is not yet stable, so the platform directory for the application
           // might not exist, to prevent it from becoming stale. If it doesn't, create one.

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -166,8 +166,6 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['create', '.'],
-                pluginExampleDirectory.path),
             ProcessCall(flutterCommand, <String>['build', 'linux'],
                 pluginExampleDirectory.path),
           ]));

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -166,8 +166,6 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['create', '.'],
-                pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,
                 <String>['drive', '-d', 'linux', deviceTestPath],


### PR DESCRIPTION
Now that the Linux app template is stable, examples should have it
checked in as usual, so the workaround is no longer needed.

Requires https://github.com/flutter/plugins/pull/3064 to land first.