### PR TITLE
Allow null-safety pre releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.42
+
+- Allow `*-nullsafety` pre release packages.
+
 ## v.0.0.41
 
 - Support `--enable-experiment` flag in subcommands `test`, `build-examples`, `drive-examples`,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.41
+version: 0.0.42
 
 dependencies:
   args: "^1.4.3"

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -286,6 +286,23 @@ void main() {
           nextVersionType: NextVersionType.BREAKING_MAJOR);
     });
 
+    test("nextVersion allows null safety pre prelease", () {
+      testAllowedVersion("1.0.1", "2.0.0-nullsafety",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("1.0.0", "2.0.0-nullsafety",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("1.0.0-nullsafety", "1.0.0-nullsafety.1",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("1.0.0-nullsafety.1", "1.0.0-nullsafety.2",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("0.1.0", "0.2.0-nullsafety",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("0.1.0-nullsafety", "0.1.0-nullsafety.1",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("0.1.0-nullsafety.1", "0.1.0-nullsafety.2",
+          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+    });
+
     test("nextVersion does not allow skipping major versions", () {
       testAllowedVersion("1.0.1", "3.0.0", allowed: false);
       testAllowedVersion("1.1.0", "2.3.0", allowed: false);


### PR DESCRIPTION
This adds support for packages such as `x.y.z-nullsafety.1`.