### PR TITLE
Fix test subcommand when --enable-experiment=exp1 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.42+1
+
+- Fix test command when `--enable-experiment` is called.
+
 ## v.0.0.42
 
 - Allow `*-nullsafety` pre release packages.

--- a/lib/src/test_command.dart
+++ b/lib/src/test_command.dart
@@ -74,9 +74,9 @@ class TestCommand extends PluginCommand {
             'pub',
             <String>[
               'run',
-              'test',
               if (enableExperiment.isNotEmpty)
                 '--enable-experiment=$enableExperiment',
+              'test',
             ],
             workingDir: packageDir,
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.42
+version: 0.0.42+1
 
 dependencies:
   args: "^1.4.3"

--- a/test/test_command_test.dart
+++ b/test/test_command_test.dart
@@ -143,7 +143,7 @@ void main() {
           ProcessCall('pub', <String>['get'], plugin2Dir.path),
           ProcessCall(
               'pub',
-              <String>['run', 'test', '--enable-experiment=exp1'],
+              <String>['run', '--enable-experiment=exp1', 'test'],
               plugin2Dir.path),
         ]),
       );

--- a/test/test_command_test.dart
+++ b/test/test_command_test.dart
@@ -90,7 +90,7 @@ void main() {
           ProcessCall('pub', <String>['get'], plugin2Dir.path),
           ProcessCall(
               'pub',
-              <String>['run', 'test', '--enable-experiment=exp1'],
+              <String>['run', '--enable-experiment=exp1', 'test'],
               plugin2Dir.path),
         ]),
       );


### PR DESCRIPTION
It turns out it should `pub run --enable-experiment=exp1 test` as opposed to `pub run  test --enable-experiment=exp1`.