### PR TITLE
Allow minor null safety preleases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.43
+
+- Allow minor `*-nullsafety` pre release packages.
+
 ## v.0.0.42+1
 
 - Fix test command when `--enable-experiment` is called.

--- a/lib/src/version_check_command.dart
+++ b/lib/src/version_check_command.dart
@@ -46,7 +46,8 @@ class GitVersionFinder {
 
 enum NextVersionType {
   BREAKING_MAJOR,
-  NULLSAFETY_PRE_RELEASE,
+  MAJOR_NULLSAFETY_PRE_RELEASE,
+  MINOR_NULLSAFETY_PRE_RELEASE,
   MINOR,
   PATCH,
   RELEASE,
@@ -77,10 +78,13 @@ Map<Version, NextVersionType> getAllowedNextVersions(
     Version masterVersion, Version headVersion) {
   final Version nextNullSafetyMajor =
       getNextNullSafetyPreRelease(masterVersion, masterVersion.nextMajor);
+  final Version nextNullSafetyMinor =
+      getNextNullSafetyPreRelease(masterVersion, masterVersion.nextMinor);
   final Map<Version, NextVersionType> allowedNextVersions =
       <Version, NextVersionType>{
     masterVersion.nextMajor: NextVersionType.BREAKING_MAJOR,
-    nextNullSafetyMajor: NextVersionType.NULLSAFETY_PRE_RELEASE,
+    nextNullSafetyMajor: NextVersionType.MAJOR_NULLSAFETY_PRE_RELEASE,
+    nextNullSafetyMinor: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE,
     masterVersion.nextMinor: NextVersionType.MINOR,
     masterVersion.nextPatch: NextVersionType.PATCH,
   };
@@ -105,10 +109,16 @@ Map<Version, NextVersionType> getAllowedNextVersions(
         NextVersionType.BREAKING_MAJOR;
     allowedNextVersions[masterVersion.nextPatch] = NextVersionType.MINOR;
     allowedNextVersions[preReleaseVersion] = NextVersionType.PATCH;
-    final Version nextNullSafetyMinor =
+
+    final Version nextNullSafetyMajor =
         getNextNullSafetyPreRelease(masterVersion, masterVersion.nextMinor);
+    final Version nextNullSafetyMinor =
+        getNextNullSafetyPreRelease(masterVersion, masterVersion.nextPatch);
+
+    allowedNextVersions[nextNullSafetyMajor] =
+        NextVersionType.MAJOR_NULLSAFETY_PRE_RELEASE;
     allowedNextVersions[nextNullSafetyMinor] =
-        NextVersionType.NULLSAFETY_PRE_RELEASE;
+        NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE;
   }
   return allowedNextVersions;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.42+1
+version: 0.0.43
 
 dependencies:
   args: "^1.4.3"

--- a/test/version_check_test.dart
+++ b/test/version_check_test.dart
@@ -288,19 +288,27 @@ void main() {
 
     test("nextVersion allows null safety pre prelease", () {
       testAllowedVersion("1.0.1", "2.0.0-nullsafety",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MAJOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("1.0.0", "2.0.0-nullsafety",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MAJOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("1.0.0-nullsafety", "1.0.0-nullsafety.1",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("1.0.0-nullsafety.1", "1.0.0-nullsafety.2",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("0.1.0", "0.2.0-nullsafety",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MAJOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("0.1.0-nullsafety", "0.1.0-nullsafety.1",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
       testAllowedVersion("0.1.0-nullsafety.1", "0.1.0-nullsafety.2",
-          nextVersionType: NextVersionType.NULLSAFETY_PRE_RELEASE);
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("1.0.0", "1.1.0-nullsafety",
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("1.1.0-nullsafety", "1.1.0-nullsafety.1",
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("0.1.0", "0.1.1-nullsafety",
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
+      testAllowedVersion("0.1.1-nullsafety", "0.1.1-nullsafety.1",
+          nextVersionType: NextVersionType.MINOR_NULLSAFETY_PRE_RELEASE);
     });
 
     test("nextVersion does not allow skipping major versions", () {


### PR DESCRIPTION
`plugin_platform_interface` is getting a minor bump in https://github.com/flutter/plugins/pull/3115

See https://github.com/flutter/plugins/pull/3115#discussion_r501952017 for details.