### PR TITLE
Remove Windows build workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.44+2
+
+- Remove pre-alpha Windows workaround to create examples on the fly.
+
 ## v.0.0.44+1
 
 - Print packages that passed tests in `xctest` command.

--- a/lib/src/build_examples_command.dart
+++ b/lib/src/build_examples_command.dart
@@ -114,20 +114,6 @@ class BuildExamplesCommand extends PluginCommand {
         if (argResults[kWindows]) {
           print('\nBUILDING Windows for $packageName');
           if (isWindowsPlugin(plugin, fileSystem)) {
-            // The Windows tooling is not yet stable, so we need to
-            // delete any existing windows directory and create a new one
-            // with 'flutter create .'
-            final Directory windowsFolder =
-                fileSystem.directory(p.join(example.path, 'windows'));
-            bool exampleCreated = false;
-            if (!windowsFolder.existsSync()) {
-              int exampleCreateCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['create', '.'],
-                  workingDir: example);
-              if (exampleCreateCode == 0) {
-                exampleCreated = true;
-              }
-            }
             int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -139,9 +125,6 @@ class BuildExamplesCommand extends PluginCommand {
                 workingDir: example);
             if (buildExitCode != 0) {
               failingPackages.add('$packageName (windows)');
-            }
-            if (exampleCreated && windowsFolder.existsSync()) {
-              windowsFolder.deleteSync(recursive: true);
             }
           } else {
             print('Windows is not supported by this plugin');

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -61,21 +61,6 @@ class DriveExamplesCommand extends PluginCommand {
         if (!(await pluginSupportedOnCurrentPlatform(plugin, fileSystem))) {
           continue;
         }
-        if (isWindows) {
-          // The Windows tooling is not yet stable, so the platform directory for the application
-          // might not exist, to prevent it from becoming stale. If it doesn't, create one.
-          final Directory windowsFolder =
-              fileSystem.directory(p.join(example.path, 'windows'));
-          if (!windowsFolder.existsSync()) {
-            int exitCode = await processRunner.runAndStream(
-                flutterCommand, <String>['create', '.'],
-                workingDir: example);
-            if (exitCode != 0) {
-              print('Failed to create a windows directory for $packageName');
-              continue;
-            }
-          }
-        }
         final Directory driverTests =
             fileSystem.directory(p.join(example.path, 'test_driver'));
         if (!driverTests.existsSync()) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.44+1
+version: 0.0.44+2
 
 dependencies:
   args: "^1.4.3"

--- a/test/build_examples_command_test.dart
+++ b/test/build_examples_command_test.dart
@@ -181,46 +181,6 @@ void main() {
       cleanupPackages();
     });
 
-    test(
-        'building for Linux does not call flutter create if a directory exists',
-        () async {
-      createFakePlugin('plugin',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'linux', 'test.h']
-          ],
-          isLinuxPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--linux']);
-      final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
-
-      expect(
-        output,
-        orderedEquals(<String>[
-          '\nBUILDING Linux for $packageName',
-          '\n\n',
-          'All builds successful!',
-        ]),
-      );
-
-      print(processRunner.recordedCalls);
-      // flutter create . should NOT be called.
-      expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['build', 'linux'],
-                pluginExampleDirectory.path),
-          ]));
-      cleanupPackages();
-    });
-
     test('building for macos with no implementation results in no-op',
         () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
@@ -355,48 +315,6 @@ void main() {
       );
 
       print(processRunner.recordedCalls);
-      expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['create', '.'],
-                pluginExampleDirectory.path),
-            ProcessCall(flutterCommand, <String>['build', 'windows'],
-                pluginExampleDirectory.path),
-          ]));
-      cleanupPackages();
-    });
-
-    test(
-        'building for windows does not call flutter create if a directory exists',
-        () async {
-      createFakePlugin('plugin',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'windows', 'test.h']
-          ],
-          isWindowsPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--windows']);
-      final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
-
-      expect(
-        output,
-        orderedEquals(<String>[
-          '\nBUILDING Windows for $packageName',
-          '\n\n',
-          'All builds successful!',
-        ]),
-      );
-
-      print(processRunner.recordedCalls);
-      // flutter create . should NOT be called.
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[

--- a/test/drive_examples_command_test.dart
+++ b/test/drive_examples_command_test.dart
@@ -276,57 +276,6 @@ void main() {
           ]));
     });
 
-    test(
-        'driving on a Linux plugin with a Linux direactory does not call flutter create',
-        () async {
-      createFakePlugin('plugin',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-            <String>['example', 'linux', 'test.h'],
-          ],
-          isLinuxPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'drive-examples',
-        '--linux',
-      ]);
-
-      expect(
-        output,
-        orderedEquals(<String>[
-          '\n\n',
-          'All driver tests successful!',
-        ]),
-      );
-
-      String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
-      print(processRunner.recordedCalls);
-      // flutter create . should NOT be called.
-      expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            ProcessCall(
-                flutterCommand,
-                <String>[
-                  'drive',
-                  '-d',
-                  'linux',
-                  '--driver',
-                  driverTestPath,
-                  '--target',
-                  deviceTestPath
-                ],
-                pluginExampleDirectory.path),
-          ]));
-    });
-
     test('driving when plugin does not suppport macOS is a no-op', () async {
       createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
@@ -403,6 +352,7 @@ void main() {
                 pluginExampleDirectory.path),
           ]));
     });
+
     test('driving when plugin does not suppport windows is a no-op', () async {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
@@ -464,58 +414,6 @@ void main() {
       String deviceTestPath = p.join('test_driver', 'plugin.dart');
       String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       print(processRunner.recordedCalls);
-      expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            ProcessCall(flutterCommand, <String>['create', '.'],
-                pluginExampleDirectory.path),
-            ProcessCall(
-                flutterCommand,
-                <String>[
-                  'drive',
-                  '-d',
-                  'windows',
-                  '--driver',
-                  driverTestPath,
-                  '--target',
-                  deviceTestPath
-                ],
-                pluginExampleDirectory.path),
-          ]));
-    });
-    test(
-        'driving on a Windows plugin with a windows direactory does not call flutter create',
-        () async {
-      createFakePlugin('plugin',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-            <String>['example', 'windows', 'test.h'],
-          ],
-          isWindowsPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'drive-examples',
-        '--windows',
-      ]);
-
-      expect(
-        output,
-        orderedEquals(<String>[
-          '\n\n',
-          'All driver tests successful!',
-        ]),
-      );
-
-      String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      String driverTestPath = p.join('test_driver', 'plugin_test.dart');
-      print(processRunner.recordedCalls);
-      // flutter create . should NOT be called.
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[


### PR DESCRIPTION
Now that the Windows app template is stable, examples should have it
checked in as usual, so the workaround is no longer needed.

Requires flutter/plugins#3149 to land first.