### PR TITLE
Add a command to run XCTests in the plugin(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.44
+
+- Add 'xctest' command to run xctests.
+
 ## v.0.0.43
 
 - Allow minor `*-nullsafety` pre release packages.

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -22,6 +22,7 @@ import 'lint_podspecs_command.dart';
 import 'list_command.dart';
 import 'test_command.dart';
 import 'version_check_command.dart';
+import 'xctest_command.dart';
 
 void main(List<String> args) {
   final FileSystem fileSystem = const LocalFileSystem();
@@ -52,7 +53,8 @@ void main(List<String> args) {
     ..addCommand(ListCommand(packagesDir, fileSystem))
     ..addCommand(PublishPluginCommand(packagesDir, fileSystem))
     ..addCommand(TestCommand(packagesDir, fileSystem))
-    ..addCommand(VersionCheckCommand(packagesDir, fileSystem));
+    ..addCommand(VersionCheckCommand(packagesDir, fileSystem))
+    ..addCommand(XCTestCommand(packagesDir, fileSystem));
 
   commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e;

--- a/lib/src/xctest_command.dart
+++ b/lib/src/xctest_command.dart
@@ -51,14 +51,14 @@ class XCTestCommand extends PluginCommand {
   Future<Null> run() async {
     if (argResults[_kTarget] == null) {
       // TODO(cyanglaz): Automatically find all the available testing schemes if this argument is not specified.
-      //
+      // https://github.com/flutter/flutter/issues/68419
       print('--$_kTarget must be specified');
       throw ToolExit(1);
     }
 
     if (argResults[_kiOSDestination] == null) {
       // TODO(cyanglaz): Automatically assign an available destination if this argument is not specified.
-      //
+      // https://github.com/flutter/flutter/issues/68419
       print('--$_kiOSDestination must be specified');
       throw ToolExit(1);
     }

--- a/lib/src/xctest_command.dart
+++ b/lib/src/xctest_command.dart
@@ -1,0 +1,239 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+
+import 'common.dart';
+
+const String kiOSDestination = 'ios-destination';
+const String kScheme = 'scheme';
+
+class XCTestCommand extends PluginCommand {
+  XCTestCommand(
+    Directory packagesDir,
+    FileSystem fileSystem, {
+    ProcessRunner processRunner = const ProcessRunner(),
+  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addOption(
+      kiOSDestination,
+      help: 'Specify the destination when running the test, used for -destination flag for xcodebuild command.',
+    );
+    argParser.addOption(
+      kScheme,
+      help: 'The test target scheme.',
+    );
+  }
+
+  @override
+  final String name = 'xctest';
+
+  @override
+  final String description =
+      'Runs the xctests in the iOS example apps.\n\n'
+      'This command requires "flutter" to be in your path.';
+
+  @override
+  Future<Null> run() async {
+    if (argResults[kScheme] == null) {
+      print(
+          '--scheme must be specified');
+      throw ToolExit(1);
+    }
+
+    if (argResults[kiOSDestination] == null) {
+      print(
+          '--ios-destination must be specified');
+      throw ToolExit(1);
+    }
+
+    checkSharding();
+
+    final String scheme = argResults[kScheme];
+    final String destination = argResults[kiOSDestination];
+
+    
+
+
+
+    print('Look for scheme named $scheme:');
+    final String findSchemeCommand = 'xcodebuild -project example/ios/Runner.xcodeproj -list -json';
+    print(findSchemeCommand);
+    final io.ProcessResult xcodeprojListResult = await processRunner.run('xcodebuld', <String>['-project', 'example/ios/Runner.xcodeproj', '-list', '-json']);
+    if (xcodeprojListResult.stderr != null) {
+      print('Error occurred while running "$findSchemeCommand":\n\n'
+            '${xcodeprojListResult.stderr}');
+      throw ToolExit(1);
+    }
+    final String xcdeprojListOutput = xcodeprojListResult.stdout;
+    if (!xcdeprojListOutput.contains(scheme)) {
+      print('$scheme not configured for this project, skipping');
+      return;
+    }
+    final String xctestCommand = 'xcodebuild test -project example/ios/Runner.xcodeproj -scheme $scheme -destination $destination CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO';
+    print(xctestCommand);
+    final int exitCode = await processRunner.runAndStream(
+                'xcodebuild',
+                <String>[
+                  'test',
+                  '-project',
+                  'example/ios/Runner.xcodeproj',
+                ],);
+
+        // final String flutterCommand =
+        // LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+
+    // final String enableExperiment = argResults[kEnableExperiment];
+    // final List<String> failingPackages = <String>[];
+    // await for (Directory plugin in getPlugins()) {
+    //   for (Directory example in getExamplesForPlugin(plugin)) {
+    //     final String packageName =
+    //         p.relative(example.path, from: packagesDir.path);
+
+    //     if (argResults[kLinux]) {
+    //       print('\nBUILDING Linux for $packageName');
+    //       if (isLinuxPlugin(plugin, fileSystem)) {
+    //         int buildExitCode = await processRunner.runAndStream(
+    //             flutterCommand,
+    //             <String>[
+    //               'build',
+    //               kLinux,
+    //               if (enableExperiment.isNotEmpty)
+    //                 '--enable-experiment=$enableExperiment',
+    //             ],
+    //             workingDir: example);
+    //         if (buildExitCode != 0) {
+    //           failingPackages.add('$packageName (linux)');
+    //         }
+    //       } else {
+    //         print('Linux is not supported by this plugin');
+    //       }
+    //     }
+
+    //     if (argResults[kMacos]) {
+    //       print('\nBUILDING macOS for $packageName');
+    //       if (isMacOsPlugin(plugin, fileSystem)) {
+    //         // TODO(https://github.com/flutter/flutter/issues/46236):
+    //         // Builing macos without running flutter pub get first results
+    //         // in an error.
+    //         int exitCode = await processRunner.runAndStream(
+    //             flutterCommand, <String>['pub', 'get'],
+    //             workingDir: example);
+    //         if (exitCode != 0) {
+    //           failingPackages.add('$packageName (macos)');
+    //         } else {
+    //           exitCode = await processRunner.runAndStream(
+    //               flutterCommand,
+    //               <String>[
+    //                 'build',
+    //                 kMacos,
+    //                 if (enableExperiment.isNotEmpty)
+    //                   '--enable-experiment=$enableExperiment',
+    //               ],
+    //               workingDir: example);
+    //           if (exitCode != 0) {
+    //             failingPackages.add('$packageName (macos)');
+    //           }
+    //         }
+    //       } else {
+    //         print('macOS is not supported by this plugin');
+    //       }
+    //     }
+
+    //     if (argResults[kWindows]) {
+    //       print('\nBUILDING Windows for $packageName');
+    //       if (isWindowsPlugin(plugin, fileSystem)) {
+    //         // The Windows tooling is not yet stable, so we need to
+    //         // delete any existing windows directory and create a new one
+    //         // with 'flutter create .'
+    //         final Directory windowsFolder =
+    //             fileSystem.directory(p.join(example.path, 'windows'));
+    //         bool exampleCreated = false;
+    //         if (!windowsFolder.existsSync()) {
+    //           int exampleCreateCode = await processRunner.runAndStream(
+    //               flutterCommand, <String>['create', '.'],
+    //               workingDir: example);
+    //           if (exampleCreateCode == 0) {
+    //             exampleCreated = true;
+    //           }
+    //         }
+    //         int buildExitCode = await processRunner.runAndStream(
+    //             flutterCommand,
+    //             <String>[
+    //               'build',
+    //               kWindows,
+    //               if (enableExperiment.isNotEmpty)
+    //                 '--enable-experiment=$enableExperiment',
+    //             ],
+    //             workingDir: example);
+    //         if (buildExitCode != 0) {
+    //           failingPackages.add('$packageName (windows)');
+    //         }
+    //         if (exampleCreated && windowsFolder.existsSync()) {
+    //           windowsFolder.deleteSync(recursive: true);
+    //         }
+    //       } else {
+    //         print('Windows is not supported by this plugin');
+    //       }
+    //     }
+
+    //     if (argResults[kIpa]) {
+    //       print('\nBUILDING IPA for $packageName');
+    //       if (isIosPlugin(plugin, fileSystem)) {
+    //         final int exitCode = await processRunner.runAndStream(
+    //             flutterCommand,
+    //             <String>[
+    //               'build',
+    //               'ios',
+    //               '--no-codesign',
+    //               if (enableExperiment.isNotEmpty)
+    //                 '--enable-experiment=$enableExperiment',
+    //             ],
+    //             workingDir: example);
+    //         if (exitCode != 0) {
+    //           failingPackages.add('$packageName (ipa)');
+    //         }
+    //       } else {
+    //         print('iOS is not supported by this plugin');
+    //       }
+    //     }
+
+    //     if (argResults[kApk]) {
+    //       print('\nBUILDING APK for $packageName');
+    //       if (isAndroidPlugin(plugin, fileSystem)) {
+    //         final int exitCode = await processRunner.runAndStream(
+    //             flutterCommand,
+    //             <String>[
+    //               'build',
+    //               'apk',
+    //               if (enableExperiment.isNotEmpty)
+    //                 '--enable-experiment=$enableExperiment',
+    //             ],
+    //             workingDir: example);
+    //         if (exitCode != 0) {
+    //           failingPackages.add('$packageName (apk)');
+    //         }
+    //       } else {
+    //         print('Android is not supported by this plugin');
+    //       }
+    //     }
+    //   }
+    // }
+    // print('\n\n');
+
+    // if (failingPackages.isNotEmpty) {
+    //   print('The following build are failing (see above for details):');
+    //   for (String package in failingPackages) {
+    //     print(' * $package');
+    //   }
+    //   throw ToolExit(1);
+    // }
+
+    // print('All builds successful!');
+  }
+}

--- a/lib/src/xctest_command.dart
+++ b/lib/src/xctest_command.dart
@@ -62,7 +62,7 @@ class XCTestCommand extends PluginCommand {
     await for (Directory plugin in getPlugins()) {
       // Start running for package.
       final String packageName =
-            p.relative(plugin.path, from: packagesDir.path);
+          p.relative(plugin.path, from: packagesDir.path);
       print('Start running for $packageName ...');
       if (!isIosPlugin(plugin, fileSystem)) {
         print('iOS is not supported by this plugin.\n\n');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.43
+version: 0.0.44
 
 dependencies:
   args: "^1.4.3"

--- a/test/xctest_command_test.dart
+++ b/test/xctest_command_test.dart
@@ -1,0 +1,88 @@
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/xctest_command.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+import 'package:test/test.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
+
+import 'util.dart';
+
+void main() {
+  group('test build_example_command', () {
+    CommandRunner<Null> runner;
+    RecordingProcessRunner processRunner;
+    final String flutterCommand =
+        LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+
+    setUp(() {
+      initializeFakePackages();
+      processRunner = RecordingProcessRunner();
+      final XCTestCommand command = XCTestCommand(
+          mockPackagesDir, mockFileSystem,
+          processRunner: processRunner);
+
+      runner = CommandRunner<Null>(
+          'xctest_command', 'Test for build_example_command');
+      runner.addCommand(command);
+      cleanupPackages();
+    });
+
+    test('Not specified ios--destination or scheme throws',
+        () async {
+
+      await expectLater(() => runner.run(<String>['xctest','--scheme', 'a_scheme']),
+          throwsA(const TypeMatcher<ToolExit>()));
+
+      await expectLater(() => runner.run(<String>['xctest','--ios-destination', 'a_destination']),
+          throwsA(const TypeMatcher<ToolExit>()));
+    });
+
+    // test('building for ios', () async {
+    //   createFakePlugin('plugin',
+    //       withExtraFiles: <List<String>>[
+    //         <String>['example', 'test'],
+    //       ],
+    //       isIosPlugin: true);
+
+    //   final Directory pluginExampleDirectory =
+    //       mockPackagesDir.childDirectory('plugin').childDirectory('example');
+
+    //   createFakePubspec(pluginExampleDirectory, isFlutter: true);
+
+    //   final List<String> output = await runCapturingPrint(runner, <String>[
+    //     'build-examples',
+    //     '--ipa',
+    //     '--no-macos',
+    //     '--enable-experiment=exp1'
+    //   ]);
+    //   final String packageName =
+    //       p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+
+    //   expect(
+    //     output,
+    //     orderedEquals(<String>[
+    //       '\nBUILDING IPA for $packageName',
+    //       '\n\n',
+    //       'All builds successful!',
+    //     ]),
+    //   );
+
+    //   print(processRunner.recordedCalls);
+    //   expect(
+    //       processRunner.recordedCalls,
+    //       orderedEquals(<ProcessCall>[
+    //         ProcessCall(
+    //             flutterCommand,
+    //             <String>[
+    //               'build',
+    //               'ios',
+    //               '--no-codesign',
+    //               '--enable-experiment=exp1'
+    //             ],
+    //             pluginExampleDirectory.path),
+    //       ]));
+    //   cleanupPackages();
+    // });
+  });
+}

--- a/test/xctest_command_test.dart
+++ b/test/xctest_command_test.dart
@@ -102,7 +102,7 @@ void main() {
 
     test('Not specifying --target throws', () async {
       await expectLater(
-          () => runner.run(<String>['xctest', _kTarget, 'a_scheme']),
+          () => runner.run(<String>['xctest', _kDestination, 'a_destination']),
           throwsA(const TypeMatcher<ToolExit>()));
     });
 
@@ -208,7 +208,6 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('xcrun', <String>['simctl', 'list', '--json'], null),
             ProcessCall(
                 'xcodebuild',
                 <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
@@ -272,7 +271,6 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall('xcrun', <String>['simctl', 'list', '--json'], null),
             ProcessCall(
                 'xcodebuild',
                 <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],

--- a/test/xctest_command_test.dart
+++ b/test/xctest_command_test.dart
@@ -23,19 +23,19 @@ void main() {
           mockPackagesDir, mockFileSystem,
           processRunner: processRunner);
 
-      runner = CommandRunner<Null>(
-          'xctest_command', 'Test for xctest_command');
+      runner = CommandRunner<Null>('xctest_command', 'Test for xctest_command');
       runner.addCommand(command);
       cleanupPackages();
     });
 
-    test('Not specifying ios--destination or scheme throws',
-        () async {
-
-      await expectLater(() => runner.run(<String>['xctest','--scheme', 'a_scheme']),
+    test('Not specifying ios--destination or scheme throws', () async {
+      await expectLater(
+          () => runner.run(<String>['xctest', '--scheme', 'a_scheme']),
           throwsA(const TypeMatcher<ToolExit>()));
 
-      await expectLater(() => runner.run(<String>['xctest','--ios-destination', 'a_destination']),
+      await expectLater(
+          () => runner
+              .run(<String>['xctest', '--ios-destination', 'a_destination']),
           throwsA(const TypeMatcher<ToolExit>()));
     });
 
@@ -43,7 +43,8 @@ void main() {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ], isIosPlugin: false);
+          ],
+          isIosPlugin: false);
 
       final Directory pluginExampleDirectory =
           mockPackagesDir.childDirectory('plugin').childDirectory('example');
@@ -53,19 +54,25 @@ void main() {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(0);
       processRunner.processToReturn = mockProcess;
-      final List<String> output = await runCapturingPrint(runner,
-          <String>['xctest', '--scheme', 'foo_scheme', '--ios-destination', 'foo_destination']);
-      expect(output, contains('iOS is not supported by this plugin.\n'
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'xctest',
+        '--scheme',
+        'foo_scheme',
+        '--ios-destination',
+        'foo_destination'
+      ]);
+      expect(
+          output,
+          contains('iOS is not supported by this plugin.\n'
               '\n'
               ''));
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[]));
+      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
 
       cleanupPackages();
     });
 
-    test('running with correct scheme and destination, did not find scheme', () async {
+    test('running with correct scheme and destination, did not find scheme',
+        () async {
       createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
@@ -81,20 +88,28 @@ void main() {
       mockProcess.exitCodeCompleter.complete(0);
       processRunner.processToReturn = mockProcess;
       processRunner.resultStdout = 'bar_scheme';
-      final List<String> output = await runCapturingPrint(runner,
-          <String>['xctest', '--scheme', 'foo_scheme', '--ios-destination', 'foo_destination']);
-
-      expect(output, contains('foo_scheme not configured for plugin, skipping.\n'
-        '\n'
-        ''));
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'xctest',
+        '--scheme',
+        'foo_scheme',
+        '--ios-destination',
+        'foo_destination'
+      ]);
 
       expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('xcodebuild',
-            <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
-              pluginExampleDirectory.path),
-        ]));
+          output,
+          contains('foo_scheme not configured for plugin, skipping.\n'
+              '\n'
+              ''));
+
+      expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                'xcodebuild',
+                <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
+                pluginExampleDirectory.path),
+          ]));
 
       cleanupPackages();
     });
@@ -115,18 +130,36 @@ void main() {
       mockProcess.exitCodeCompleter.complete(0);
       processRunner.processToReturn = mockProcess;
       processRunner.resultStdout = 'foo_scheme, bar_scheme';
-      await runner.run(
-          <String>['xctest', '--scheme', 'foo_scheme', '--ios-destination', 'foo_destination']);
+      await runner.run(<String>[
+        'xctest',
+        '--scheme',
+        'foo_scheme',
+        '--ios-destination',
+        'foo_destination'
+      ]);
 
       expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('xcodebuild',
-            <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
-              pluginExampleDirectory.path),
-          ProcessCall('xcodebuild', <String>['test', '-project', 'ios/Runner.xcodeproj', '-scheme', 'foo_scheme', '-destination', 'foo_destination', 'CODE_SIGN_IDENTITY=""', 'CODE_SIGNING_REQUIRED=NO'],
-              pluginExampleDirectory.path),
-        ]));
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall(
+                'xcodebuild',
+                <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
+                pluginExampleDirectory.path),
+            ProcessCall(
+                'xcodebuild',
+                <String>[
+                  'test',
+                  '-project',
+                  'ios/Runner.xcodeproj',
+                  '-scheme',
+                  'foo_scheme',
+                  '-destination',
+                  'foo_destination',
+                  'CODE_SIGN_IDENTITY=""',
+                  'CODE_SIGNING_REQUIRED=NO'
+                ],
+                pluginExampleDirectory.path),
+          ]));
 
       cleanupPackages();
     });

--- a/test/xctest_command_test.dart
+++ b/test/xctest_command_test.dart
@@ -165,6 +165,7 @@ void main() {
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
+              ProcessCall('xcrun', <String>['simctl', 'list', '--json'], null),
               ProcessCall(
                   'xcodebuild',
                   <String>[
@@ -207,6 +208,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall('xcrun', <String>['simctl', 'list', '--json'], null),
             ProcessCall(
                 'xcodebuild',
                 <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
@@ -270,6 +272,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall('xcrun', <String>['simctl', 'list', '--json'], null),
             ProcessCall(
                 'xcodebuild',
                 <String>['-project', 'ios/Runner.xcodeproj', '-list', '-json'],
@@ -341,7 +344,7 @@ void main() {
                   '-scheme',
                   'foo_scheme',
                   '-destination',
-                  'id=2706BBEB-1E01-403E-A8E9-70E8E5A24774',
+                  'id=1E76A0FD-38AC-4537-A989-EA639D7D012A',
                   'CODE_SIGN_IDENTITY=""',
                   'CODE_SIGNING_REQUIRED=NO'
                 ],


### PR DESCRIPTION
The command runs as `xctest --scheme <scheme> --ios-destination <destination>`
As for this first version, on CI, we need to hard code the <scheme> and <destination>. Which serves our needs for now.

Future improvements(if supported by xcodebuild tool) could be made around things like: automatically select test schemes, automatically select available devices.

After landing this, we can enable XCUITests in flutter/plugin, so plugins with native UI could be better tested on iOS.