### PR TITLE
XCTests: fix output messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v.0.0.44+1
+
+- Print packages that passed tests in `xctest` command.
+- Remove printing the whole list of simulators.
+
 ## v.0.0.44
 
 - Add 'xctest' command to run xctests.

--- a/lib/src/xctest_command.dart
+++ b/lib/src/xctest_command.dart
@@ -143,7 +143,9 @@ class XCTestCommand extends PluginCommand {
         print(completeTestCommand);
         final int exitCode = await processRunner
             .runAndStream(_kXcodeBuildCommand, xctestArgs, workingDir: example);
-        if (exitCode != 0) {
+        if (exitCode == 0) {
+          print('Successfully ran xctest for $packageName');
+        } else {
           failingPackages.add(packageName);
         }
       }
@@ -180,7 +182,6 @@ class XCTestCommand extends PluginCommand {
           '${findSimulatorsResult.stderr}');
       throw ToolExit(1);
     }
-    print(findSimulatorsResult.stdout);
     final Map<String, dynamic> simulatorListJson =
         jsonDecode(findSimulatorsResult.stdout);
     final List<dynamic> runtimes = simulatorListJson['runtimes'];
@@ -206,8 +207,7 @@ class XCTestCommand extends PluginCommand {
           continue;
         }
         id = device['udid'];
-        print('device selected: ');
-        print(device);
+        print('device selected: $device');
         return id;
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.44
+version: 0.0.44+1
 
 dependencies:
   args: "^1.4.3"

--- a/test/xctest_command_test.dart
+++ b/test/xctest_command_test.dart
@@ -197,13 +197,15 @@ void main() {
       processRunner.processToReturn = mockProcess;
       processRunner.resultStdout =
           '{"project":{"targets":["bar_scheme", "foo_scheme"]}}';
-      await runner.run(<String>[
+      List<String> output = await runCapturingPrint(runner, <String>[
         'xctest',
         _kTarget,
         'foo_scheme',
         _kDestination,
         'foo_destination'
       ]);
+
+      expect(output, contains('Successfully ran xctest for plugin'));
 
       expect(
           processRunner.recordedCalls,
@@ -267,6 +269,7 @@ void main() {
       ]);
 
       expect(output, contains('plugin1 was skipped with the --skip flag.'));
+      expect(output, contains('Successfully ran xctest for plugin2'));
 
       expect(
           processRunner.recordedCalls,


### PR DESCRIPTION
- Print packages that passed tests in `xctest` command.
- Remove printing the whole list of simulators.