### PR TITLE
remove -v flag in drive-examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.029
+
+- Remove `-v` flag on drive-examples.
+
 ## v.0.0.44+4
 
 - Fix bug where directory isn't passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v.0.029
+## v.0.0.44+5
 
 - Remove `-v` flag on drive-examples.
 

--- a/lib/src/drive_examples_command.dart
+++ b/lib/src/drive_examples_command.dart
@@ -120,7 +120,7 @@ Tried searching for the following:
             }
           }
 
-          final List<String> driveArgs = <String>['drive', '-v'];
+          final List<String> driveArgs = <String>['drive'];
 
           final String enableExperiment = argResults[kEnableExperiment];
           if (enableExperiment.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
   pedantic: 1.8.0
 
 environment:
-  sdk: ">=2.11.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.44+4
+version: 0.0.44+5
 
 dependencies:
   args: "^1.4.3"
@@ -27,4 +27,4 @@ dev_dependencies:
   pedantic: 1.8.0
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"


### PR DESCRIPTION
The `-v` flag seems to cause a time-out in `flutter pub get`