### PR TITLE
Don't override the AGP version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.44+7
+
+- `all-plugins-app` doesn't override the AGP version.
+
 ## v.0.0.44+6
 
 - Fix code formatting.

--- a/lib/src/create_all_plugins_app_command.dart
+++ b/lib/src/create_all_plugins_app_command.dart
@@ -45,7 +45,6 @@ class CreateAllPluginsAppCommand extends PluginCommand {
       _genPubspecWithAllPlugins(),
       _updateAppGradle(),
       _updateManifest(),
-      _updateProjectGradle(),
     ]);
   }
 
@@ -64,23 +63,6 @@ class CreateAllPluginsAppCommand extends PluginCommand {
     print(result.stdout);
     print(result.stderr);
     return result.exitCode;
-  }
-
-  Future<void> _updateProjectGradle() async {
-    final File gradleFile = fileSystem.file(p.join(
-      'all_plugins',
-      'android',
-      'build.gradle',
-    ));
-    if (!gradleFile.existsSync()) {
-      throw ToolExit(64);
-    }
-
-    final String newGradle = gradleFile.readAsStringSync().replaceFirst(
-          RegExp(r"classpath \'com.android.tools.build:gradle:\d.\d.\d\'"),
-          'classpath \'com.android.tools.build:gradle:3.3.1\'',
-        );
-    gradleFile.writeAsStringSync(newGradle);
   }
 
   Future<void> _updateAppGradle() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.44+6
+version: 0.0.44+7
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
The AGP version cannot be overridden without changing the Gradle version as well. I don't know why this was introduced in https://github.com/flutter/plugin_tools/pull/52, but I don't think it's currently needed.