### PR TITLE
Don't format .dart files if there are no files to format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.45+1
+
+- Don't call `flutter format` if there are no Dart files to format.
+
 ## v.0.0.45
 
 - Add exclude flag to exclude any plugin from further processing.

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -115,7 +115,8 @@ class FormatCommand extends PluginCommand {
     print('Formatting all .dart files...');
     final Iterable<String> dartFiles = await _getFilesWithExtension('.dart');
     if (dartFiles.isEmpty) {
-      print('No .dart files to format. If you set the `--exclude` flag, most likey they were skipped');
+      print(
+          'No .dart files to format. If you set the `--exclude` flag, most likey they were skipped');
     } else {
       await processRunner.runAndStream(
           'flutter', <String>['format']..addAll(dartFiles),

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -114,9 +114,13 @@ class FormatCommand extends PluginCommand {
     // specifically shell out to dartfmt -w in that case.
     print('Formatting all .dart files...');
     final Iterable<String> dartFiles = await _getFilesWithExtension('.dart');
-    await processRunner.runAndStream(
-        'flutter', <String>['format']..addAll(dartFiles),
-        workingDir: packagesDir, exitOnError: true);
+    if (dartFiles.isEmpty) {
+      print('No dart files to format. If you set the `--exclude` flag, most likey they were skipped');
+    } else {
+      await processRunner.runAndStream(
+          'flutter', <String>['format']..addAll(dartFiles),
+          workingDir: packagesDir, exitOnError: true);
+    }
   }
 
   Future<List<String>> _getFilesWithExtension(String extension) async =>

--- a/lib/src/format_command.dart
+++ b/lib/src/format_command.dart
@@ -115,7 +115,7 @@ class FormatCommand extends PluginCommand {
     print('Formatting all .dart files...');
     final Iterable<String> dartFiles = await _getFilesWithExtension('.dart');
     if (dartFiles.isEmpty) {
-      print('No dart files to format. If you set the `--exclude` flag, most likey they were skipped');
+      print('No .dart files to format. If you set the `--exclude` flag, most likey they were skipped');
     } else {
       await processRunner.runAndStream(
           'flutter', <String>['format']..addAll(dartFiles),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.45
+version: 0.0.45+1
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
packages  specified in `--exclude` are skipped. This causes `flutter format` to fail since it requires at least one file or `.`.

Test: This will be tested once this repo is moved to `flutter/plugins`. Similar to how devicelab related code is tested while it's being run in the CI.