### PR TITLE
Make `publish-plugin` to work on non-flutter packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.0.0.45+2
+
+- Make `publish-plugin` to work on non-flutter packages.
+
 ## v.0.0.45+1
 
 - Don't call `flutter format` if there are no Dart files to format.

--- a/lib/src/publish_plugin_command.dart
+++ b/lib/src/publish_plugin_command.dart
@@ -134,10 +134,6 @@ class PublishPluginCommand extends PluginCommand {
       _print('${_packageDir.absolute.path} does not exist.');
       throw ToolExit(1);
     }
-    if (!isFlutterPackage(_packageDir, fileSystem)) {
-      _print('${_packageDir.absolute.path} is not a flutter package.');
-      throw ToolExit(1);
-    }
     return _packageDir;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.45+3
+version: 0.0.45+2
 
 dependencies:
   args: "^1.4.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
 homepage: https://github.com/flutter/plugin_tools
-version: 0.0.45+1
+version: 0.0.45+3
 
 dependencies:
   args: "^1.4.3"

--- a/test/publish_plugin_command_test.dart
+++ b/test/publish_plugin_command_test.dart
@@ -112,6 +112,25 @@ void main() {
 
       expect(printedMessages.last, 'Done!');
     });
+
+    test('can publish non-flutter package', () async {
+      createFakePubspec(pluginDir, includeVersion: true, isFlutter: false);
+      io.Process.runSync('git', <String>['init'],
+          workingDirectory: mockPackagesDir.path);
+      gitDir = await GitDir.fromExisting(mockPackagesDir.path);
+      await gitDir.runCommand(<String>['add', '-A']);
+      await gitDir.runCommand(<String>['commit', '-m', 'Initial commit']);
+      // Immediately return 0 when running `pub publish`.
+      processRunner.mockPublishProcess.exitCodeCompleter.complete(0);
+      await commandRunner.run(<String>[
+        'publish-plugin',
+        '--package',
+        testPluginName,
+        '--no-push-tags',
+        '--no-tag-release'
+      ]);
+      expect(printedMessages.last, 'Done!');
+    });
   });
 
   group('Publishes package', () {


### PR DESCRIPTION
Non flutter packages should also be able to use `publish-plugin`. For example: https://github.com/flutter/plugins/blob/master/packages/plugin_platform_interface/pubspec.yaml

We can let `pub publish` command to validate if the package is publishable for us. 